### PR TITLE
Improve UI Component Types

### DIFF
--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -3,6 +3,7 @@ import classnames from '@sindresorhus/class-names'
 import { h } from 'preact'
 import { useCallback } from 'preact/hooks'
 
+import { HTMLProps } from '../../types'
 import { ENTER_KEY_CODE, ESCAPE_KEY_CODE } from '../../utilities/key-codes'
 import { LoadingIndicator } from '../loading-indicator/loading-indicator'
 import styles from './button.scss'
@@ -30,7 +31,7 @@ export function Button({
   propagateEscapeKeyDown = true,
   secondary,
   ...rest
-}: ButtonProps): h.JSX.Element {
+}: HTMLProps<ButtonProps, HTMLButtonElement>): h.JSX.Element {
   const handleKeyDown = useCallback(
     function (event: KeyboardEvent) {
       const keyCode = event.keyCode

--- a/packages/ui/src/components/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/checkbox/checkbox.tsx
@@ -3,7 +3,7 @@ import classnames from '@sindresorhus/class-names'
 import { h } from 'preact'
 import { useCallback } from 'preact/hooks'
 
-import { OnChange } from '../../types'
+import { HTMLProps, OnChange } from '../../types'
 import { ENTER_KEY_CODE, ESCAPE_KEY_CODE } from '../../utilities/key-codes'
 import styles from './checkbox.scss'
 
@@ -28,7 +28,7 @@ export function Checkbox({
   propagateEscapeKeyDown = true,
   value,
   ...rest
-}: CheckboxProps): h.JSX.Element {
+}: HTMLProps<CheckboxProps, HTMLInputElement>): h.JSX.Element {
   const handleChange = useCallback(
     function (event: Event) {
       const newValue = !(value === true)

--- a/packages/ui/src/components/columns/columns.tsx
+++ b/packages/ui/src/components/columns/columns.tsx
@@ -2,7 +2,7 @@
 import classnames from '@sindresorhus/class-names'
 import { h, toChildArray } from 'preact'
 
-import { Space } from '../../types'
+import { HTMLProps, Space } from '../../types'
 import styles from './columns.scss'
 
 export interface ColumnsProps {
@@ -14,7 +14,7 @@ export function Columns({
   children,
   space,
   ...rest
-}: ColumnsProps): h.JSX.Element {
+}: HTMLProps<ColumnsProps, HTMLDivElement>): h.JSX.Element {
   return (
     <div
       {...rest}

--- a/packages/ui/src/components/container/container.tsx
+++ b/packages/ui/src/components/container/container.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'preact'
 
-import { Space } from '../../types'
+import { HTMLProps, Space } from '../../types'
 import styles from './container.scss'
 
 export interface ContainerProps {
@@ -12,6 +12,6 @@ export interface ContainerProps {
 export function Container({
   space = 'small',
   ...rest
-}: ContainerProps): h.JSX.Element {
+}: HTMLProps<ContainerProps, HTMLDivElement>): h.JSX.Element {
   return <div {...rest} class={styles[space]} />
 }

--- a/packages/ui/src/components/file-upload-button/file-upload-button.tsx
+++ b/packages/ui/src/components/file-upload-button/file-upload-button.tsx
@@ -3,7 +3,7 @@ import classnames from '@sindresorhus/class-names'
 import { h } from 'preact'
 import { useCallback } from 'preact/hooks'
 
-import { OnSelectedFiles } from '../../types'
+import { HTMLProps, OnSelectedFiles } from '../../types'
 import { ESCAPE_KEY_CODE } from '../../utilities/key-codes'
 import { LoadingIndicator } from '../loading-indicator/loading-indicator'
 import styles from './file-upload-button.scss'
@@ -33,7 +33,7 @@ export function FileUploadButton({
   onSelectedFiles,
   propagateEscapeKeyDown = true,
   ...rest
-}: FileUploadButtonProps): h.JSX.Element {
+}: HTMLProps<FileUploadButtonProps, HTMLInputElement>): h.JSX.Element {
   const handleClick = useCallback(function (event: MouseEvent) {
     ;(event.target as HTMLElement).focus()
   }, [])

--- a/packages/ui/src/components/file-upload-dropzone/file-upload-dropzone.tsx
+++ b/packages/ui/src/components/file-upload-dropzone/file-upload-dropzone.tsx
@@ -3,7 +3,7 @@ import classnames from '@sindresorhus/class-names'
 import { h } from 'preact'
 import { useCallback, useState } from 'preact/hooks'
 
-import { OnSelectedFiles } from '../../types'
+import { HTMLProps, OnSelectedFiles } from '../../types'
 import { ESCAPE_KEY_CODE } from '../../utilities/key-codes'
 import styles from './file-upload-dropzone.scss'
 
@@ -22,7 +22,7 @@ export function FileUploadDropzone({
   onSelectedFiles,
   propagateEscapeKeyDown = true,
   ...rest
-}: FileUploadDropzoneProps): h.JSX.Element {
+}: HTMLProps<FileUploadDropzoneProps, HTMLInputElement>): h.JSX.Element {
   const [isDropActive, setIsDropActive] = useState(false)
   const filterFiles = useCallback(
     function (files: FileList): Array<File> {

--- a/packages/ui/src/components/inline/inline.tsx
+++ b/packages/ui/src/components/inline/inline.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h, toChildArray } from 'preact'
 
-import { Space } from '../../types'
+import { HTMLProps, Space } from '../../types'
 import styles from './inline.scss'
 
 export interface InlineProps {
@@ -13,7 +13,7 @@ export function Inline({
   children,
   space,
   ...rest
-}: InlineProps): h.JSX.Element {
+}: HTMLProps<InlineProps, HTMLDivElement>): h.JSX.Element {
   return (
     <div
       {...rest}

--- a/packages/ui/src/components/layer/layer.tsx
+++ b/packages/ui/src/components/layer/layer.tsx
@@ -2,6 +2,7 @@
 import classnames from '@sindresorhus/class-names'
 import { h } from 'preact'
 
+import { HTMLProps } from '../../types'
 import { componentIcon } from '../icon/icons/component-icon'
 import { frameIcon } from '../icon/icons/frame-icon'
 import styles from './layer.scss'
@@ -27,7 +28,7 @@ export function Layer({
   selected,
   type,
   ...rest
-}: LayerProps): h.JSX.Element {
+}: HTMLProps<LayerProps, HTMLDivElement>): h.JSX.Element {
   return (
     <div
       {...rest}

--- a/packages/ui/src/components/preview/preview.tsx
+++ b/packages/ui/src/components/preview/preview.tsx
@@ -1,13 +1,17 @@
 /** @jsx h */
 import { h } from 'preact'
 
+import { HTMLProps } from '../../types'
 import style from './preview.scss'
 
 export interface PreviewProps {
   children: preact.ComponentChildren
 }
 
-export function Preview({ children, ...rest }: PreviewProps): h.JSX.Element {
+export function Preview({
+  children,
+  ...rest
+}: HTMLProps<PreviewProps, HTMLDivElement>): h.JSX.Element {
   return (
     <div {...rest} class={style.preview}>
       {children}

--- a/packages/ui/src/components/radio-buttons/radio-buttons.tsx
+++ b/packages/ui/src/components/radio-buttons/radio-buttons.tsx
@@ -3,7 +3,7 @@ import classnames from '@sindresorhus/class-names'
 import { h } from 'preact'
 import { useCallback } from 'preact/hooks'
 
-import { OnChange, Space } from '../../types'
+import { HTMLProps, OnChange, Space } from '../../types'
 import { ESCAPE_KEY_CODE } from '../../utilities/key-codes'
 import { Stack } from '../stack/stack'
 import styles from './radio-buttons.scss'
@@ -34,7 +34,7 @@ export function RadioButtons({
   space = 'small',
   value,
   ...rest
-}: RadioButtonsProps): h.JSX.Element {
+}: HTMLProps<RadioButtonsProps, HTMLInputElement>): h.JSX.Element {
   const handleKeyDown = useCallback(
     function (event: KeyboardEvent) {
       const keyCode = event.keyCode

--- a/packages/ui/src/components/search-textbox/search-textbox.tsx
+++ b/packages/ui/src/components/search-textbox/search-textbox.tsx
@@ -2,7 +2,7 @@
 import { h } from 'preact'
 import { useCallback, useRef } from 'preact/hooks'
 
-import { OnChange } from '../../types'
+import { HTMLProps, OnChange } from '../../types'
 import { ESCAPE_KEY_CODE } from '../../utilities/key-codes'
 import { crossIcon } from '../icon/icons/cross-icon'
 import { searchIcon } from '../icon/icons/search-icon'
@@ -29,7 +29,7 @@ export function SearchTextbox({
   propagateEscapeKeyDown = true,
   value,
   ...rest
-}: SearchTextboxProps): h.JSX.Element {
+}: HTMLProps<SearchTextboxProps, HTMLInputElement>): h.JSX.Element {
   const inputElementRef: preact.RefObject<HTMLInputElement> = useRef(null)
 
   function handleFocus() {

--- a/packages/ui/src/components/segmented-control/segmented-control.tsx
+++ b/packages/ui/src/components/segmented-control/segmented-control.tsx
@@ -2,7 +2,7 @@
 import { h } from 'preact'
 import { useCallback } from 'preact/hooks'
 
-import { OnChange } from '../../types'
+import { HTMLProps, OnChange } from '../../types'
 import {
   DOWN_KEY_CODE,
   ESCAPE_KEY_CODE,
@@ -37,7 +37,7 @@ export function SegmentedControl<T extends string | number | boolean = string>({
   propagateEscapeKeyDown = true,
   value,
   ...rest
-}: SegmentedControlProps<T>): h.JSX.Element {
+}: HTMLProps<SegmentedControlProps<T>, HTMLInputElement>): h.JSX.Element {
   const handleChange = useCallback(
     function (event: Event) {
       const index = (event.target as HTMLElement).getAttribute('data-index')

--- a/packages/ui/src/components/selectable-item/selectable-item.tsx
+++ b/packages/ui/src/components/selectable-item/selectable-item.tsx
@@ -3,7 +3,7 @@ import classnames from '@sindresorhus/class-names'
 import { h } from 'preact'
 import { useCallback } from 'preact/hooks'
 
-import { OnChange } from '../../types'
+import { HTMLProps, OnChange } from '../../types'
 import { ENTER_KEY_CODE, ESCAPE_KEY_CODE } from '../../utilities/key-codes'
 import { checkIcon } from '../icon/icons/check-icon'
 import styles from './selectable-item.scss'
@@ -31,7 +31,7 @@ export function SelectableItem({
   propagateEscapeKeyDown = true,
   value,
   ...rest
-}: SelectableItemProps): h.JSX.Element {
+}: HTMLProps<SelectableItemProps, HTMLInputElement>): h.JSX.Element {
   const handleChange = useCallback(
     function (event: Event) {
       const newValue = !(value === true)
@@ -66,7 +66,7 @@ export function SelectableItem({
 
   return (
     <label
-      {...rest}
+      {...(rest as any)}
       class={classnames(
         styles.label,
         disabled === true ? styles.disabled : null,

--- a/packages/ui/src/components/stack/stack.tsx
+++ b/packages/ui/src/components/stack/stack.tsx
@@ -2,7 +2,7 @@
 import classnames from '@sindresorhus/class-names'
 import { h, toChildArray } from 'preact'
 
-import { Space } from '../../types'
+import { HTMLProps, Space } from '../../types'
 import styles from './stack.scss'
 
 export interface StackProps {
@@ -14,7 +14,7 @@ export function Stack({
   children,
   space = 'small',
   ...rest
-}: StackProps): h.JSX.Element {
+}: HTMLProps<StackProps, HTMLDivElement>): h.JSX.Element {
   return (
     <div {...rest} class={classnames(styles[space])}>
       {toChildArray(children).map(function (element, index) {

--- a/packages/ui/src/components/tabs/tabs.tsx
+++ b/packages/ui/src/components/tabs/tabs.tsx
@@ -2,7 +2,7 @@
 import { h } from 'preact'
 import { useCallback } from 'preact/hooks'
 
-import { OnChange } from '../../types'
+import { HTMLProps, OnChange } from '../../types'
 import {
   DOWN_KEY_CODE,
   ESCAPE_KEY_CODE,
@@ -36,7 +36,7 @@ export function Tabs({
   propagateEscapeKeyDown = true,
   value,
   ...rest
-}: TabsProps): h.JSX.Element {
+}: HTMLProps<TabsProps, HTMLInputElement>): h.JSX.Element {
   const handleChange = useCallback(
     function (event: Event) {
       const index = (event.target as HTMLElement).getAttribute('data-index')

--- a/packages/ui/src/components/text/text.tsx
+++ b/packages/ui/src/components/text/text.tsx
@@ -2,7 +2,7 @@
 import classnames from '@sindresorhus/class-names'
 import { h } from 'preact'
 
-import { Alignment } from '../../types'
+import { Alignment, HTMLProps } from '../../types'
 import styles from './text.scss'
 
 export interface TextProps {
@@ -20,7 +20,7 @@ export function Text({
   muted,
   numeric,
   ...rest
-}: TextProps): h.JSX.Element {
+}: HTMLProps<TextProps, HTMLDivElement>): h.JSX.Element {
   return (
     <div
       {...rest}

--- a/packages/ui/src/components/textbox/textbox-autocomplete/textbox-autocomplete.tsx
+++ b/packages/ui/src/components/textbox/textbox-autocomplete/textbox-autocomplete.tsx
@@ -5,7 +5,7 @@ import classnames from '@sindresorhus/class-names'
 import { h } from 'preact'
 import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks'
 
-import { Option } from '../../../types'
+import { HTMLProps, Option } from '../../../types'
 import {
   BACKSPACE_KEY_CODE,
   DELETE_KEY_CODE,
@@ -49,7 +49,7 @@ export function TextboxAutocomplete({
   top,
   value: committedValue,
   ...rest
-}: TextboxAutocompleteProps): h.JSX.Element {
+}: HTMLProps<TextboxAutocompleteProps, HTMLInputElement>): h.JSX.Element {
   const rootElementRef: preact.RefObject<HTMLDivElement> = useRef(null)
   const inputElementRef: preact.RefObject<HTMLInputElement> = useRef(null)
   const menuElementRef: preact.RefObject<HTMLDivElement> = useRef(null)

--- a/packages/ui/src/components/textbox/textbox-numeric/textbox-numeric.tsx
+++ b/packages/ui/src/components/textbox/textbox-numeric/textbox-numeric.tsx
@@ -9,6 +9,7 @@ import classnames from '@sindresorhus/class-names'
 import { h } from 'preact'
 import { useCallback, useRef } from 'preact/hooks'
 
+import { HTMLProps } from '../../../types'
 import {
   DOWN_KEY_CODE,
   ESCAPE_KEY_CODE,
@@ -46,7 +47,7 @@ export function TextboxNumeric({
   propagateEscapeKeyDown = true,
   value,
   ...rest
-}: TextboxNumericProps): h.JSX.Element {
+}: HTMLProps<TextboxNumericProps, HTMLInputElement>): h.JSX.Element {
   const hasIcon = typeof icon !== 'undefined'
 
   const inputElementRef: preact.RefObject<HTMLInputElement> = useRef(null)

--- a/packages/ui/src/components/textbox/textbox.tsx
+++ b/packages/ui/src/components/textbox/textbox.tsx
@@ -3,7 +3,7 @@ import classnames from '@sindresorhus/class-names'
 import { h } from 'preact'
 import { useCallback, useRef } from 'preact/hooks'
 
-import { OnChange } from '../../types'
+import { HTMLProps, OnChange } from '../../types'
 import { ESCAPE_KEY_CODE } from '../../utilities/key-codes'
 import styles from './textbox.scss'
 
@@ -30,7 +30,7 @@ export function Textbox({
   propagateEscapeKeyDown = true,
   value,
   ...rest
-}: TextboxProps): h.JSX.Element {
+}: HTMLProps<TextboxProps, HTMLInputElement>): h.JSX.Element {
   const hasIcon = typeof icon !== 'undefined'
 
   const inputElementRef: preact.RefObject<HTMLInputElement> = useRef(null)

--- a/packages/ui/src/components/vertical-space/vertical-space.tsx
+++ b/packages/ui/src/components/vertical-space/vertical-space.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'preact'
 
-import { Space } from '../../types'
+import { HTMLProps, Space } from '../../types'
 import styles from './vertical-space.scss'
 
 export interface VerticalSpaceProps {
@@ -11,6 +11,6 @@ export interface VerticalSpaceProps {
 export function VerticalSpace({
   space = 'small',
   ...rest
-}: VerticalSpaceProps): h.JSX.Element {
+}: HTMLProps<VerticalSpaceProps, HTMLDivElement>): h.JSX.Element {
   return <div {...rest} class={styles[space]} />
 }

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -1,4 +1,12 @@
+import { h } from 'preact'
+
 export type Alignment = 'left' | 'center' | 'right'
+
+export type HTMLProps<Props, RefType extends EventTarget = EventTarget> = Omit<
+  h.JSX.HTMLAttributes<RefType>,
+  keyof Props
+> &
+  Props
 
 export type OnChange = (
   state?: any,


### PR DESCRIPTION
Most of the components currently accept `...rest` props, but the public types don't expose them. This PR remedies that which should lead to a better DX for TS users.

- Add `...rest` props to public component types
- Add `HTMLProps` interface to `types`