### PR TITLE
Update custom CSS doc instructions

### DIFF
--- a/docs/recipes/ui.md
+++ b/docs/recipes/ui.md
@@ -80,7 +80,7 @@ Out of the box, the `build-figma-plugin` CLI supports [CSS Modules](https://gith
 ```scss
 // src/styles.scss
 
-@import "@create-figma-plugin/ui/src/scss/constants";
+@import "@create-figma-plugin/ui/lib/scss/constants";
 
 .container {
   background-color: $color-black-10;


### PR DESCRIPTION
The docs for custom SCSS referenced `@import "@create-figma-plugin/ui/src/scss/constants";`, but `src` isn't included in the published module.

This updates the docs to reference `@import "@create-figma-plugin/ui/lib/scss/constants";`