### PR TITLE
remove modules length

### DIFF
--- a/packages/build/src/build-bundle-async.ts
+++ b/packages/build/src/build-bundle-async.ts
@@ -74,9 +74,7 @@ async function createMainEntryFileAsync(
   const fileContent = `
     require('@create-figma-plugin/utilities/lib/events');
     const modules = ${createRequireCode(modules)};
-    const commandId = ${
-      modules.length > 1 ? 'figma.command' : `'${modules[0].commandId}'`
-    };
+    const commandId = '${modules[0].commandId}';
     modules[commandId]();
   `
   return tempWrite(fileContent)


### PR DESCRIPTION
closes #19 

The `modules` length is always larger than 1, so by default, it is just to use `modules[0].commandId`.