### PR TITLE
feat: <Textbox> password input prop

### DIFF
--- a/packages/ui/src/components/textbox/textbox.stories.tsx
+++ b/packages/ui/src/components/textbox/textbox.stories.tsx
@@ -53,10 +53,10 @@ export const Password = function () {
   const [state, setState] = useState({ foo: 'Hidden Text' })
   return (
     <Textbox
-      inputType="password"
       name="foo"
       noBorder
       onChange={setState}
+      type="password"
       value={state.foo}
     />
   )

--- a/packages/ui/src/components/textbox/textbox.stories.tsx
+++ b/packages/ui/src/components/textbox/textbox.stories.tsx
@@ -49,6 +49,19 @@ export const NoBorder = function () {
   return <Textbox name="foo" noBorder onChange={setState} value={state.foo} />
 }
 
+export const Password = function () {
+  const [state, setState] = useState({ foo: 'Hidden Text' })
+  return (
+    <Textbox
+      inputType="password"
+      name="foo"
+      noBorder
+      onChange={setState}
+      value={state.foo}
+    />
+  )
+}
+
 export const WithIcon = function () {
   const [state, setState] = useState({ foo: '' })
   return (

--- a/packages/ui/src/components/textbox/textbox.tsx
+++ b/packages/ui/src/components/textbox/textbox.tsx
@@ -16,7 +16,7 @@ export interface TextboxProps {
   onChange: OnChange
   placeholder?: string
   propagateEscapeKeyDown?: boolean
-  inputType?: 'text' | 'password'
+  type?: 'text' | 'password'
   value: null | string
 }
 
@@ -29,7 +29,7 @@ export function Textbox({
   onChange,
   placeholder,
   propagateEscapeKeyDown = true,
-  inputType = 'text',
+  type = 'text',
   value,
   ...rest
 }: HTMLProps<TextboxProps, HTMLInputElement>): h.JSX.Element {
@@ -114,7 +114,7 @@ export function Textbox({
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         tabIndex={disabled === true ? undefined : 0}
-        type={inputType}
+        type={type}
         value={value === null ? 'Mixed' : value}
       />
       {hasIcon ? <div class={styles.icon}>{icon}</div> : null}

--- a/packages/ui/src/components/textbox/textbox.tsx
+++ b/packages/ui/src/components/textbox/textbox.tsx
@@ -16,6 +16,7 @@ export interface TextboxProps {
   onChange: OnChange
   placeholder?: string
   propagateEscapeKeyDown?: boolean
+  inputType?: 'text' | 'password'
   value: null | string
 }
 
@@ -28,6 +29,7 @@ export function Textbox({
   onChange,
   placeholder,
   propagateEscapeKeyDown = true,
+  inputType = 'text',
   value,
   ...rest
 }: HTMLProps<TextboxProps, HTMLInputElement>): h.JSX.Element {
@@ -112,7 +114,7 @@ export function Textbox({
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         tabIndex={disabled === true ? undefined : 0}
-        type="text"
+        type={inputType}
         value={value === null ? 'Mixed' : value}
       />
       {hasIcon ? <div class={styles.icon}>{icon}</div> : null}


### PR DESCRIPTION
Hey @yuanqing, thanks for making this awesome project. This PR extends `<Textbox>` to have an `inputType` property with `'text'` by default and `'password'` if the user wants to hide some input field.

![image](https://user-images.githubusercontent.com/15751908/101590081-9b6a8f00-399e-11eb-9ccc-8c8a49a73db8.png)

