### PR TITLE
Fix build error log format

### DIFF
--- a/packages/build/src/build-bundle-async.ts
+++ b/packages/build/src/build-bundle-async.ts
@@ -56,7 +56,7 @@ export async function buildBundleAsync(
           reject('An unknown error occurred')
           return
         }
-        reject(errors.join('\n'))
+        reject(errors.map((error) => error.message).join('\n\n'))
         return
       }
       resolve()


### PR DESCRIPTION
This change fixes an issue where errors emitted by webpack stats would
show as `[object Object]`.