### PR TITLE
Optimize incremental webpack builds

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -1,6 +1,7 @@
 export const constants = {
   apiVersion: '1.0.0',
   build: {
+    cacheDirectoryName: 'build/cache',
     directoryName: 'build',
     manifestFilePath: 'manifest.json',
     pluginCodeFilePath: 'build/main.js',


### PR DESCRIPTION
This change aims to optimize incremental builds in development. It currently does the following:

- Adds a cache directory for webpack builds (located in `<project dir>/build/cache/webpack`)
- Adds a cache directory for babel builds with babel-loader (located in `<project dir>/build/cache/babel-loader`). Compression has been disabled.
- Disables minification of build files.

These changes currently only apply in development mode (e.g. using `--watch` and `--dev` flags).

I have personally noticed a significant decrease in build time. Of a fairly small project with a few dependencies that are a few KBs each (and using preact) went from about ~9-10 seconds to ~500ms-2s for incremental builds.

---

One "issue" this introduces is that if there are any errors emitted by ts-loader/babel-loader, i.e. type errors from TypeScript, the following message will show:

```
<w> [webpack.cache.PackFileCacheStrategy] Skipped not serializable cache item 'Compilation/modules|<project dir>/node_modules/babel-loader/lib/index.js??ruleSet[1].rules[1].use[0]!<project dir>node_modules/ts-loader/index.js!<project dir>/src/main.ts': Circular references can't be serialized
<w> while serializing webpack/lib/cache/PackFileCacheStrategy.PackContentItems -> webpack/lib/NormalModule -> Array { 1 items } -> Object { message, file, loc, location, loaderSource, module } -> webpack/lib/NormalModule
```

I haven't found a solution to this but it won't affect the build and will disappear once all errors have been resolved.

Related to #23 