### PR TITLE
Allow parameterOnly to be explicitly set to false

### DIFF
--- a/packages/build/src/utilities/build-manifest-async.ts
+++ b/packages/build/src/utilities/build-manifest-async.ts
@@ -64,7 +64,8 @@ export async function buildManifestAsync(minify: boolean): Promise<void> {
       command.parameters !== null
         ? createParameters(command.parameters)
         : undefined,
-    parameterOnly: command.parameterOnly === true ? true : undefined,
+    parameterOnly:
+      command.parameterOnly !== null ? command.parameterOnly : undefined,
     menu: command.menu !== null ? createMenu(command.menu) : undefined,
     relaunchButtons:
       relaunchButtons !== null

--- a/packages/build/test/build-async/build-async.ts
+++ b/packages/build/test/build-async/build-async.ts
@@ -587,6 +587,41 @@ test('override manifest', async function (t) {
   await cleanUpAsync()
 })
 
+test('both ui and parameters', async function (t) {
+  t.plan(5)
+  process.chdir(join(__dirname, 'fixtures', '19-ui-with-parameters'))
+  await cleanUpAsync()
+  t.false(await fs.pathExists('build'))
+  t.false(await fs.pathExists('node_modules'))
+  await installFigmaPluginTypingsAsync()
+  await symlinkCreateFigmaPluginTsConfigAsync()
+  await buildAsync({
+    clearPreviousLine: false,
+    minify: false,
+    typecheck: true
+  })
+  const manifestJson = JSON.parse(await fs.readFile('manifest.json', 'utf8'))
+  t.deepEqual(manifestJson, {
+    api: '1.0.0',
+    editorType: ['figma'],
+    id: '42',
+    main: 'build/main.js',
+    name: 'a',
+    parameterOnly: false,
+    parameters: [
+      {
+        description: 'Some option',
+        key: 'option',
+        name: 'Option'
+      }
+    ],
+    ui: 'build/ui.js'
+  })
+  t.true(await fs.pathExists('build/main.js'))
+  t.true(await fs.pathExists('build/ui.js'))
+  await cleanUpAsync()
+})
+
 async function installFigmaPluginTypingsAsync(): Promise<void> {
   await fs.ensureDir(join(process.cwd(), 'node_modules'))
   await new Promise<void>(function (resolve, reject) {

--- a/packages/build/test/build-async/fixtures/19-ui-with-parameters/build-figma-plugin.ui.js
+++ b/packages/build/test/build-async/fixtures/19-ui-with-parameters/build-figma-plugin.ui.js
@@ -1,0 +1,8 @@
+module.exports = function (buildOptions) {
+  return {
+    ...buildOptions,
+    footer: {
+      js: '// comment appended to ui.js'
+    }
+  }
+}

--- a/packages/build/test/build-async/fixtures/19-ui-with-parameters/package.json
+++ b/packages/build/test/build-async/fixtures/19-ui-with-parameters/package.json
@@ -9,7 +9,6 @@
         "name": "Option",
         "key": "option",
         "description": "Some option"
-  
       }
     ],
     "parameterOnly": false

--- a/packages/build/test/build-async/fixtures/19-ui-with-parameters/package.json
+++ b/packages/build/test/build-async/fixtures/19-ui-with-parameters/package.json
@@ -1,0 +1,17 @@
+{
+  "figma-plugin": {
+    "id": "42",
+    "name": "a",
+    "main": "src/main.ts",
+    "ui": "src/ui.ts",
+    "parameters": [
+      {
+        "name": "Option",
+        "key": "option",
+        "description": "Some option"
+  
+      }
+    ],
+    "parameterOnly": false
+  }
+}

--- a/packages/build/test/build-async/fixtures/19-ui-with-parameters/src/main.ts
+++ b/packages/build/test/build-async/fixtures/19-ui-with-parameters/src/main.ts
@@ -1,0 +1,21 @@
+import { showUI } from '@create-figma-plugin/utilities'
+
+export default function () {
+  const options = { height: 120, width: 240 }
+  const data = { greeting: 'Hello, World!' }
+
+  figma.parameters.on('input', async ({ key, result }: ParameterInputEvent) => {
+    if (key === 'option') {
+      result.setSuggestions(['Option 1', 'Option 2'])
+    }
+  })
+
+  figma.on('run', ({ parameters }: RunEvent) => {
+    if (parameters) {
+      // some action based on parameters
+      figma.closePlugin(`Hello from the other side`)
+    } else {
+      showUI(options, data)
+    }
+  })
+}

--- a/packages/build/test/build-async/fixtures/19-ui-with-parameters/src/ui.ts
+++ b/packages/build/test/build-async/fixtures/19-ui-with-parameters/src/ui.ts
@@ -1,0 +1,3 @@
+export default function (rootNode: HTMLElement, data: { greeting: string }) {
+  rootNode.innerHTML = `<p>${data.greeting}</p>`
+}

--- a/packages/build/test/build-async/fixtures/19-ui-with-parameters/tsconfig.json
+++ b/packages/build/test/build-async/fixtures/19-ui-with-parameters/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@create-figma-plugin/tsconfig",
+  "compilerOptions": {
+    "typeRoots": ["node_modules/@figma"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/common/src/read-config-async.ts
+++ b/packages/common/src/read-config-async.ts
@@ -35,7 +35,7 @@ const defaultConfig: Config = {
   },
   menu: null,
   name: constants.packageJson.defaultName,
-  parameterOnly: false,
+  parameterOnly: null,
   parameters: null,
   permissions: null,
   relaunchButtons: null,
@@ -116,7 +116,7 @@ function parseCommand(command: RawConfigCommand): ConfigCommand {
             return parseCommand(command)
           }),
     name,
-    parameterOnly: typeof parameterOnly === 'undefined' ? false : parameterOnly,
+    parameterOnly: typeof parameterOnly === 'undefined' ? null : parameterOnly,
     parameters:
       typeof parameters === 'undefined' ? null : parseParameters(parameters),
     ui: typeof ui === 'undefined' ? null : parseFile(ui)

--- a/packages/common/src/types/config.ts
+++ b/packages/common/src/types/config.ts
@@ -8,7 +8,7 @@ interface BaseConfigMixin {
 export interface ConfigCommand extends BaseConfigMixin {
   readonly menu: null | Array<ConfigCommand | ConfigCommandSeparator>
   readonly parameters: null | Array<ConfigParameter>
-  readonly parameterOnly: boolean
+  readonly parameterOnly: null | boolean
 }
 
 export interface Config extends ConfigCommand {

--- a/packages/common/test/additional-fields/additional-fields.ts
+++ b/packages/common/test/additional-fields/additional-fields.ts
@@ -12,7 +12,7 @@ const config = {
   main: { handler: 'default', src: 'b' },
   menu: null,
   name: 'a',
-  parameterOnly: false,
+  parameterOnly: null,
   parameters: null,
   relaunchButtons: null,
   ui: null

--- a/packages/common/test/basic-command-with-parameters/basic-command-with-parameters.ts
+++ b/packages/common/test/basic-command-with-parameters/basic-command-with-parameters.ts
@@ -29,7 +29,7 @@ test('single parameter', async function (t) {
   process.chdir(join(__dirname, 'fixtures', '01-single-parameter'))
   t.deepEqual(await readConfigAsync(), {
     ...config,
-    parameterOnly: false,
+    parameterOnly: null,
     parameters: [
       {
         allowFreeform: false,
@@ -47,7 +47,7 @@ test('name', async function (t) {
   process.chdir(join(__dirname, 'fixtures', '02-name'))
   t.deepEqual(await readConfigAsync(), {
     ...config,
-    parameterOnly: false,
+    parameterOnly: null,
     parameters: [
       {
         allowFreeform: false,
@@ -65,7 +65,7 @@ test('description', async function (t) {
   process.chdir(join(__dirname, 'fixtures', '03-description'))
   t.deepEqual(await readConfigAsync(), {
     ...config,
-    parameterOnly: false,
+    parameterOnly: null,
     parameters: [
       {
         allowFreeform: false,
@@ -83,7 +83,7 @@ test('allow freeform', async function (t) {
   process.chdir(join(__dirname, 'fixtures', '04-allow-freeform'))
   t.deepEqual(await readConfigAsync(), {
     ...config,
-    parameterOnly: false,
+    parameterOnly: null,
     parameters: [
       {
         allowFreeform: true,
@@ -101,7 +101,7 @@ test('optional', async function (t) {
   process.chdir(join(__dirname, 'fixtures', '05-optional'))
   t.deepEqual(await readConfigAsync(), {
     ...config,
-    parameterOnly: false,
+    parameterOnly: null,
     parameters: [
       {
         allowFreeform: false,
@@ -119,7 +119,7 @@ test('multiple parameters', async function (t) {
   process.chdir(join(__dirname, 'fixtures', '06-multiple-parameters'))
   t.deepEqual(await readConfigAsync(), {
     ...config,
-    parameterOnly: false,
+    parameterOnly: null,
     parameters: [
       {
         allowFreeform: true,

--- a/packages/common/test/basic-command/basic-command.ts
+++ b/packages/common/test/basic-command/basic-command.ts
@@ -14,7 +14,7 @@ const config = {
   enablePrivatePluginApi: false,
   enableProposedApi: false,
   menu: null,
-  parameterOnly: false,
+  parameterOnly: null,
   parameters: null,
   permissions: null,
   relaunchButtons: null,

--- a/packages/common/test/empty/empty.ts
+++ b/packages/common/test/empty/empty.ts
@@ -18,7 +18,7 @@ const config = {
   main: { handler: 'default', src: 'src/main.ts' },
   menu: null,
   name: 'figma-plugin',
-  parameterOnly: false,
+  parameterOnly: null,
   parameters: null,
   permissions: null,
   relaunchButtons: null,

--- a/packages/common/test/multiple-menu-commands/multiple-menu-commands.ts
+++ b/packages/common/test/multiple-menu-commands/multiple-menu-commands.ts
@@ -17,7 +17,7 @@ const config = {
   id: 'a',
   main: null,
   name: 'a',
-  parameterOnly: false,
+  parameterOnly: null,
   parameters: null,
   permissions: null,
   relaunchButtons: null,
@@ -39,7 +39,7 @@ test('multiple commands', async function (t) {
         },
         menu: null,
         name: 'b',
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: null,
         ui: null
       },
@@ -51,7 +51,7 @@ test('multiple commands', async function (t) {
         },
         menu: null,
         name: 'd',
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: null,
         ui: {
           handler: 'default',
@@ -76,7 +76,7 @@ test('separator', async function (t) {
         },
         menu: null,
         name: 'b',
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: null,
         ui: null
       },
@@ -89,7 +89,7 @@ test('separator', async function (t) {
         },
         menu: null,
         name: 'd',
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: null,
         ui: {
           handler: 'default',
@@ -114,7 +114,7 @@ test('nested', async function (t) {
         },
         menu: null,
         name: 'b',
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: null,
         ui: null
       },
@@ -130,7 +130,7 @@ test('nested', async function (t) {
             },
             menu: null,
             name: 'e',
-            parameterOnly: false,
+            parameterOnly: null,
             parameters: null,
             ui: {
               handler: 'default',
@@ -139,7 +139,7 @@ test('nested', async function (t) {
           }
         ],
         name: 'd',
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: null,
         ui: null
       }
@@ -161,7 +161,7 @@ test('parameters', async function (t) {
         },
         menu: null,
         name: 'b',
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: null,
         ui: null
       },

--- a/packages/common/test/relaunch-buttons/relaunch-buttons.ts
+++ b/packages/common/test/relaunch-buttons/relaunch-buttons.ts
@@ -18,7 +18,7 @@ const config = {
   main: { handler: 'default', src: 'b' },
   menu: null,
   name: 'a',
-  parameterOnly: false,
+  parameterOnly: null,
   parameters: null,
   permissions: null,
   ui: null,

--- a/packages/common/test/single-menu-command-with-parameters/single-menu-command-with-parameters.ts
+++ b/packages/common/test/single-menu-command-with-parameters/single-menu-command-with-parameters.ts
@@ -17,7 +17,7 @@ const config = {
   id: 'a',
   main: null,
   name: 'a',
-  parameterOnly: false,
+  parameterOnly: null,
   parameters: null,
   permissions: null,
   relaunchButtons: null,
@@ -44,7 +44,7 @@ test('single parameter', async function (t) {
     menu: [
       {
         ...menuItemConfig,
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: [
           {
             allowFreeform: false,
@@ -67,7 +67,7 @@ test('name', async function (t) {
     menu: [
       {
         ...menuItemConfig,
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: [
           {
             allowFreeform: false,
@@ -90,7 +90,7 @@ test('description', async function (t) {
     menu: [
       {
         ...menuItemConfig,
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: [
           {
             allowFreeform: false,
@@ -113,7 +113,7 @@ test('allow freeform', async function (t) {
     menu: [
       {
         ...menuItemConfig,
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: [
           {
             allowFreeform: true,
@@ -136,7 +136,7 @@ test('optional', async function (t) {
     menu: [
       {
         ...menuItemConfig,
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: [
           {
             allowFreeform: false,
@@ -159,7 +159,7 @@ test('multiple parameters', async function (t) {
     menu: [
       {
         ...menuItemConfig,
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: [
           {
             allowFreeform: true,

--- a/packages/common/test/single-menu-command/single-menu-command.ts
+++ b/packages/common/test/single-menu-command/single-menu-command.ts
@@ -16,7 +16,7 @@ const config = {
   enableProposedApi: false,
   main: null,
   name: 'a',
-  parameterOnly: false,
+  parameterOnly: null,
   parameters: null,
   permissions: null,
   relaunchButtons: null,
@@ -39,7 +39,7 @@ test('`main`', async function (t) {
         },
         menu: null,
         name: 'b',
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: null,
         ui: null
       }
@@ -62,7 +62,7 @@ test('`main` with named export', async function (t) {
         },
         menu: null,
         name: 'b',
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: null,
         ui: null
       }
@@ -85,7 +85,7 @@ test('`ui`', async function (t) {
         },
         menu: null,
         name: 'b',
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: null,
         ui: {
           handler: 'default',
@@ -111,7 +111,7 @@ test('`ui` with named export', async function (t) {
         },
         menu: null,
         name: 'b',
-        parameterOnly: false,
+        parameterOnly: null,
         parameters: null,
         ui: {
           handler: 'e',


### PR DESCRIPTION
It turned out that parameterOnly is being ignored if it is set to false in package.json.
According to Figma docs the default value for parameterOnly is true, so we need to allow changing it to false.
But changing default value to "true" cases pollution manifest with parameterOnly every time even if it isn't present in our package.json.
So I changed the default value to null to include parameterOnly in manifest only if it is present in package.json
  