### PR TITLE
Reposition Dropdown menu when selection is empty

### DIFF
--- a/packages/ui/src/components/dropdown/dropdown.tsx
+++ b/packages/ui/src/components/dropdown/dropdown.tsx
@@ -371,14 +371,13 @@ function updateMenuElementLayout(
   const maximumTopOffset = rootElementBoundingClientRect.top - VIEWPORT_MARGIN
 
   if (menuElement.offsetHeight < menuElementMaxHeight) {
-    if (selectedId === INVALID_ID) {
-      return
-    }
-
     // Try to adjust the `top` position of `menuElement` such that
-    // `selectedElement` is directly above the `rootElement`
+    // either `selectedElement` or the first element is
+    // directly above the `rootElement`
     const selectedElement = menuElement.querySelector<HTMLInputElement>(
-      `[${ITEM_ID_DATA_ATTRIBUTE_NAME}='${selectedId}']`
+      selectedId === INVALID_ID
+        ? 'label:first-child input'
+        : `[${ITEM_ID_DATA_ATTRIBUTE_NAME}='${selectedId}']`
     )
     if (selectedElement === null) {
       throw new Error('Invariant violation') // `selectedId` is valid


### PR DESCRIPTION
Steps to reproduce issue:
- Add a Dropdown component with empty (null) value
- Add 10 or more Dropdown options
- Position the Dropdown near the top of the plugin window

When selection is empty, the Dropdown component positions its menu vertically centered in relation to the dropdown. With a large enough list of options, the menu could get cut off at the top, with no way to scroll up.

In this PR we position the menu such that the first menu item is directly above the dropdown component when dropdown selected value is null.

![dropdown-update](https://user-images.githubusercontent.com/7082849/168520889-b0e52e97-e7da-43bc-9ec2-d79abb090235.png)
