### PR TITLE
Add `space="medium"` to Container in the widget/notepad templates.

### DIFF
--- a/packages/create-figma-plugin/templates/widget/notepad/src/ui.tsx
+++ b/packages/create-figma-plugin/templates/widget/notepad/src/ui.tsx
@@ -19,7 +19,7 @@ function Plugin (props: { text: string }) {
     [text]
   )
   return (
-    <Container>
+    <Container space='medium'>
       <VerticalSpace space='large' />
       <TextboxMultiline
         {...useInitialFocus()}


### PR DESCRIPTION
I added missing `space` props to Container in the widget/notepad templates.