### PR TITLE
Allow TypeScript 5.x

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "@figma/plugin-typings": "^1",
-    "typescript": "^4"
+    "typescript": ">=4"
   },
   "ava": {
     "extensions": {


### PR DESCRIPTION
👋 `typescript@next` is in the 5.0.0-dev.* range now, and I’ve been using it for a few days with `create-figma-plugin` with no problems. I think it should be safe to allow it as a peer dependency. (For context, TypeScript versions simply roll to the next major version after the minor passes `9`, so there’s not much meaning behind restricting the major version range.) Thanks!