### PR TITLE
Add `capabilities` field to manifest.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2246,9 +2246,9 @@
       }
     },
     "node_modules/@figma/plugin-typings": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.54.0.tgz",
-      "integrity": "sha512-jetMn5s9p+X/iB+ZXbUrMI++8zhK21n6W9KT/IAz4DfI9NMy0+URlEaySmqRMyKwZUMVRhzYO10QzQLfOXk1fQ==",
+      "version": "1.57.1",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.57.1.tgz",
+      "integrity": "sha512-kwiuApuqgkIPbFKey459VspenqXlBcBoMTnTZdQ/Hk2N71BTOZ0cM5Xq3zbPW/bEQOYtGDpweWxcXYHLo19HxQ==",
       "dev": true
     },
     "node_modules/@gar/promisify": {
@@ -34476,7 +34476,7 @@
       "devDependencies": {
         "@create-figma-plugin/tsconfig": "^2.1.6",
         "@create-figma-plugin/utilities": "^2.1.6",
-        "@figma/plugin-typings": "1.54.0",
+        "@figma/plugin-typings": "1.57.1",
         "@types/fs-extra": "^9.0.13",
         "@types/node": "^18.11.3",
         "@types/react": "^18.0.21",
@@ -35086,7 +35086,7 @@
         "rgb-hex": "^4.0.0"
       },
       "devDependencies": {
-        "@figma/plugin-typings": "1.54.0",
+        "@figma/plugin-typings": "1.57.1",
         "@types/fs-extra": "^9.0.13",
         "@types/natural-compare-lite": "^1.4.0",
         "@types/node": "^18.11.3",
@@ -36740,7 +36740,7 @@
         "@create-figma-plugin/common": "^2.1.6",
         "@create-figma-plugin/tsconfig": "^2.1.6",
         "@create-figma-plugin/utilities": "^2.1.6",
-        "@figma/plugin-typings": "1.54.0",
+        "@figma/plugin-typings": "1.57.1",
         "@types/fs-extra": "^9.0.13",
         "@types/node": "^18.11.3",
         "@types/react": "^18.0.21",
@@ -36943,7 +36943,7 @@
     "@create-figma-plugin/utilities": {
       "version": "file:packages/utilities",
       "requires": {
-        "@figma/plugin-typings": "1.54.0",
+        "@figma/plugin-typings": "1.57.1",
         "@types/fs-extra": "^9.0.13",
         "@types/natural-compare-lite": "^1.4.0",
         "@types/node": "^18.11.3",
@@ -37055,9 +37055,9 @@
       }
     },
     "@figma/plugin-typings": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.54.0.tgz",
-      "integrity": "sha512-jetMn5s9p+X/iB+ZXbUrMI++8zhK21n6W9KT/IAz4DfI9NMy0+URlEaySmqRMyKwZUMVRhzYO10QzQLfOXk1fQ==",
+      "version": "1.57.1",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.57.1.tgz",
+      "integrity": "sha512-kwiuApuqgkIPbFKey459VspenqXlBcBoMTnTZdQ/Hk2N71BTOZ0cM5Xq3zbPW/bEQOYtGDpweWxcXYHLo19HxQ==",
       "dev": true
     },
     "@gar/promisify": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@create-figma-plugin/tsconfig": "^2.1.6",
     "@create-figma-plugin/utilities": "^2.1.6",
-    "@figma/plugin-typings": "1.54.0",
+    "@figma/plugin-typings": "1.57.1",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^18.11.3",
     "@types/react": "^18.0.21",

--- a/packages/build/src/figma-plugin.json
+++ b/packages/build/src/figma-plugin.json
@@ -232,6 +232,12 @@
         "enableProposedApi": {
           "description": "(optional)\nSet to `true` to allow the use of Proposed APIs that are only available during development.",
           "type": "boolean"
+        },
+        "capabilities": {
+          "description": "(optional)\nFor specifying the capabilities your plugin has access to. At the moment the only applicable capability is 'textreview'.",
+          "type": "array",
+          "minItems": 1,
+          "items": [{ "enum": ["textreview"] }]
         }
       }
     }

--- a/packages/build/src/types/manifest.ts
+++ b/packages/build/src/types/manifest.ts
@@ -15,6 +15,7 @@ export type Manifest = {
   enableProposedApi?: boolean
   enablePrivatePluginApi?: boolean
   build?: string
+  capabilities?: Array<string>
 }
 
 export type ManifestMenuItem = {

--- a/packages/build/src/utilities/build-manifest-async.ts
+++ b/packages/build/src/utilities/build-manifest-async.ts
@@ -22,6 +22,7 @@ export async function buildManifestAsync(minify: boolean): Promise<void> {
   const {
     api,
     build,
+    capabilities,
     commandId,
     containsWidget,
     editorType,
@@ -73,7 +74,8 @@ export async function buildManifestAsync(minify: boolean): Promise<void> {
     permissions: permissions !== null ? permissions : undefined,
     enableProposedApi: enableProposedApi === true ? true : undefined,
     enablePrivatePluginApi: enablePrivatePluginApi === true ? true : undefined,
-    build: build !== null ? build : undefined
+    build: build !== null ? build : undefined,
+    capabilities: capabilities !== null ? capabilities : undefined
   }
   /* eslint-enable sort-keys-fix/sort-keys-fix */
   const result = await overrideManifestAsync(manifest)

--- a/packages/build/test/build-async/build-async.ts
+++ b/packages/build/test/build-async/build-async.ts
@@ -305,6 +305,7 @@ test('additional fields', async function (t) {
   t.deepEqual(manifestJson, {
     api: '42',
     build: 'a',
+    capabilities: ['textreview'],
     containsWidget: true,
     editorType: ['figjam'],
     enablePrivatePluginApi: true,

--- a/packages/build/test/build-async/fixtures/09-additional-fields/package.json
+++ b/packages/build/test/build-async/fixtures/09-additional-fields/package.json
@@ -14,6 +14,9 @@
     ],
     "enablePrivatePluginApi": true,
     "enableProposedApi": true,
-    "build": "a"
+    "build": "a",
+    "capabilities": [
+      "textreview"
+    ]
   }
 }

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -16,7 +16,7 @@ export const constants = {
     configKey: 'figma-plugin',
     defaultName: 'figma-plugin',
     versions: {
-      pluginTypings: '1.54.0',
+      pluginTypings: '1.57.1',
       widgetTypings: '1.5.0'
     }
   }

--- a/packages/common/src/read-config-async.ts
+++ b/packages/common/src/read-config-async.ts
@@ -23,6 +23,7 @@ import {
 const defaultConfig: Config = {
   api: constants.build.manifestPluginApi,
   build: null,
+  capabilities: null,
   commandId: join(constants.build.srcDirectoryName, 'main.ts--default'),
   containsWidget: false,
   editorType: ['figma'],
@@ -58,6 +59,7 @@ export async function readConfigAsync(): Promise<Config> {
   const {
     api,
     build,
+    capabilities,
     containsWidget,
     editorType,
     enableProposedApi,
@@ -76,6 +78,7 @@ export async function readConfigAsync(): Promise<Config> {
   return {
     api: typeof api === 'undefined' ? constants.build.manifestPluginApi : api,
     build: typeof build === 'undefined' ? null : build,
+    capabilities: typeof capabilities === 'undefined' ? null : capabilities,
     containsWidget:
       typeof containsWidget === 'undefined' ? false : containsWidget,
     editorType: typeof editorType === 'undefined' ? ['figma'] : editorType,

--- a/packages/common/src/types/config.ts
+++ b/packages/common/src/types/config.ts
@@ -22,6 +22,7 @@ export interface Config extends ConfigCommand {
   readonly enableProposedApi: boolean
   readonly enablePrivatePluginApi: boolean
   readonly build: null | string
+  readonly capabilities: null | Array<string>
 }
 
 export type ConfigCommandSeparator = { readonly separator: true }

--- a/packages/common/src/types/raw-config.ts
+++ b/packages/common/src/types/raw-config.ts
@@ -21,6 +21,7 @@ export interface RawConfig extends RawConfigCommand {
   readonly enableProposedApi?: boolean
   readonly enablePrivatePluginApi?: boolean
   readonly build?: string
+  readonly capabilities?: Array<string>
 }
 
 export type RawConfigCommandSeparator = '-'

--- a/packages/common/test/additional-fields/additional-fields.ts
+++ b/packages/common/test/additional-fields/additional-fields.ts
@@ -25,6 +25,7 @@ test('`api`', async function (t) {
     ...config,
     api: '42',
     build: null,
+    capabilities: null,
     containsWidget: false,
     editorType: ['figma'],
     enablePrivatePluginApi: false,
@@ -41,6 +42,7 @@ test('`widgetApi`', async function (t) {
     ...config,
     api: '1.0.0',
     build: null,
+    capabilities: null,
     containsWidget: true,
     editorType: ['figma'],
     enablePrivatePluginApi: false,
@@ -57,6 +59,7 @@ test('`editorType`', async function (t) {
     ...config,
     api: '1.0.0',
     build: null,
+    capabilities: null,
     containsWidget: false,
     editorType: ['figjam', 'figma'],
     enablePrivatePluginApi: false,
@@ -73,6 +76,7 @@ test('`containsWidget`', async function (t) {
     ...config,
     api: '1.0.0',
     build: null,
+    capabilities: null,
     containsWidget: true,
     editorType: ['figjam'],
     enablePrivatePluginApi: false,
@@ -89,6 +93,7 @@ test('`enablePrivatePluginApi`', async function (t) {
     ...config,
     api: '1.0.0',
     build: null,
+    capabilities: null,
     containsWidget: false,
     editorType: ['figma'],
     enablePrivatePluginApi: true,
@@ -105,6 +110,7 @@ test('`enableProposedApi`', async function (t) {
     ...config,
     api: '1.0.0',
     build: null,
+    capabilities: null,
     containsWidget: false,
     editorType: ['figma'],
     enablePrivatePluginApi: false,
@@ -121,6 +127,24 @@ test('`build`', async function (t) {
     ...config,
     api: '1.0.0',
     build: 'c',
+    capabilities: null,
+    containsWidget: false,
+    editorType: ['figma'],
+    enablePrivatePluginApi: false,
+    enableProposedApi: false,
+    permissions: null,
+    widgetApi: '1.0.0'
+  })
+})
+
+test('`capabilities`', async function (t) {
+  t.plan(1)
+  process.chdir(join(__dirname, 'fixtures', '08-capabilities'))
+  t.deepEqual(await readConfigAsync(), {
+    ...config,
+    api: '1.0.0',
+    build: null,
+    capabilities: ['textreview'],
     containsWidget: false,
     editorType: ['figma'],
     enablePrivatePluginApi: false,

--- a/packages/common/test/additional-fields/fixtures/08-capabilities/package.json
+++ b/packages/common/test/additional-fields/fixtures/08-capabilities/package.json
@@ -1,0 +1,9 @@
+{
+  "figma-plugin": {
+    "name": "a",
+    "main": "b",
+    "capabilities": [
+      "textreview"
+    ]
+  }
+}

--- a/packages/common/test/basic-command-with-parameters/basic-command-with-parameters.ts
+++ b/packages/common/test/basic-command-with-parameters/basic-command-with-parameters.ts
@@ -9,6 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const config = {
   api: '1.0.0',
   build: null,
+  capabilities: null,
   commandId: 'b--default',
   containsWidget: false,
   editorType: ['figma'],

--- a/packages/common/test/basic-command/basic-command.ts
+++ b/packages/common/test/basic-command/basic-command.ts
@@ -9,6 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const config = {
   api: '1.0.0',
   build: null,
+  capabilities: null,
   containsWidget: false,
   editorType: ['figma'],
   enablePrivatePluginApi: false,

--- a/packages/common/test/empty/empty.ts
+++ b/packages/common/test/empty/empty.ts
@@ -9,6 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const config = {
   api: '1.0.0',
   build: null,
+  capabilities: null,
   commandId: 'src/main.ts--default',
   containsWidget: false,
   editorType: ['figma'],

--- a/packages/common/test/multiple-menu-commands/multiple-menu-commands.ts
+++ b/packages/common/test/multiple-menu-commands/multiple-menu-commands.ts
@@ -9,6 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const config = {
   api: '1.0.0',
   build: null,
+  capabilities: null,
   commandId: null,
   containsWidget: false,
   editorType: ['figma'],

--- a/packages/common/test/relaunch-buttons/relaunch-buttons.ts
+++ b/packages/common/test/relaunch-buttons/relaunch-buttons.ts
@@ -9,6 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const config = {
   api: '1.0.0',
   build: null,
+  capabilities: null,
   commandId: 'b--default',
   containsWidget: false,
   editorType: ['figma'],

--- a/packages/common/test/single-menu-command-with-parameters/single-menu-command-with-parameters.ts
+++ b/packages/common/test/single-menu-command-with-parameters/single-menu-command-with-parameters.ts
@@ -9,6 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const config = {
   api: '1.0.0',
   build: null,
+  capabilities: null,
   commandId: null,
   containsWidget: false,
   editorType: ['figma'],

--- a/packages/common/test/single-menu-command/single-menu-command.ts
+++ b/packages/common/test/single-menu-command/single-menu-command.ts
@@ -9,6 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const config = {
   api: '1.0.0',
   build: null,
+  capabilities: null,
   commandId: null,
   containsWidget: false,
   editorType: ['figma'],

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -44,7 +44,7 @@
     "rgb-hex": "^4.0.0"
   },
   "devDependencies": {
-    "@figma/plugin-typings": "1.54.0",
+    "@figma/plugin-typings": "1.57.1",
     "@types/fs-extra": "^9.0.13",
     "@types/natural-compare-lite": "^1.4.0",
     "@types/node": "^18.11.3",

--- a/packages/website/docs/configuration.md
+++ b/packages/website/docs/configuration.md
@@ -224,6 +224,12 @@ See the [recipe for configuring relaunch buttons](<%- query('page', 'recipes').u
 
 *Optional.* Set to `true` to allow the use of [Proposed APIs](https://figma.com/plugin-docs/proposed-api/) that are only available during development.
 
+### `capabilities`
+
+(*`Array<string>`*)
+
+*Optional.* For specifying the capabilities your plugin has access to. At the moment the only applicable capability is `['textreview']`.
+
 ## JSON schema
 
 Validate the plugin configuration in your `package.json` file using [Create Figma Plugin’s configuration JSON schema](https://yuanqing.github.io/create-figma-plugin/figma-plugin.json).


### PR DESCRIPTION
I want to use the [Text Review API](https://www.figma.com/plugin-docs/api/figma-textreview), so I added the necessary fields.

References: 
https://www.figma.com/plugin-docs/updates/2022/12/06/version-1-update-57
https://www.figma.com/plugin-docs/manifest/#capabilities