### PR TITLE
Add support for codegen manifest options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27646,7 +27646,7 @@
       }
     },
     "packages/create-figma-plugin": {
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "@create-figma-plugin/common": "^2.5.1",
@@ -27663,7 +27663,7 @@
         "title-case": "^3.0.3"
       },
       "bin": {
-        "create-figma-plugin": "undefined2.5.1"
+        "create-figma-plugin": "lib/cli.js"
       },
       "devDependencies": {
         "@types/fs-extra": "^11.0.1",
@@ -27800,7 +27800,7 @@
       }
     },
     "packages/website": {
-      "version": "2.5.0",
+      "version": "2.5.1",
       "devDependencies": {
         "@types/fs-extra": "^11.0.1",
         "@types/text-table": "^0.2.2",

--- a/packages/build/src/types/manifest.ts
+++ b/packages/build/src/types/manifest.ts
@@ -16,6 +16,8 @@ export type Manifest = {
   enableProposedApi?: boolean
   enablePrivatePluginApi?: boolean
   build?: string
+  codegenLanguages?: Array<ManifestCodeLanguage>
+  codegenPreferences?: Array<ManifestCodegenPreference>
 }
 
 export type ManifestMenuItem = {
@@ -40,4 +42,26 @@ export type ManifestRelaunchButton = {
   command: string
   name: string
   multipleSelection?: true
+}
+
+export type ManifestCodeLanguage = {
+  label: string
+  value: string
+}
+
+export type ManifestCodegenPreferenceOption = {
+  label: string
+  value: string
+  isDefault?: boolean
+}
+
+export type ManifestCodegenPreference = {
+  itemType: string
+  defaultScaleFactor?: number
+  scaledUnit?: string
+  default?: boolean
+  propertyName?: string
+  label?: string
+  options?: Array<ManifestCodegenPreferenceOption>
+  includedLanguages?: Array<string>
 }

--- a/packages/build/src/utilities/build-manifest-async.ts
+++ b/packages/build/src/utilities/build-manifest-async.ts
@@ -6,11 +6,17 @@ import {
   constants,
   readConfigAsync
 } from '@create-figma-plugin/common'
+import {
+  ConfigCodegenPreference,
+  ConfigCodegenPreferenceOption
+} from '@create-figma-plugin/common/lib/types/config'
 import fs from 'fs-extra'
 import { globby } from 'globby'
 
 import {
   Manifest,
+  ManifestCodegenPreference,
+  ManifestCodegenPreferenceOption,
   ManifestMenuItem,
   ManifestMenuItemSeparator,
   ManifestParameter,
@@ -23,6 +29,8 @@ export async function buildManifestAsync(minify: boolean): Promise<void> {
     api,
     build,
     capabilities,
+    codegenLanguages,
+    codegenPreferences,
     commandId,
     containsWidget,
     editorType,
@@ -73,6 +81,11 @@ export async function buildManifestAsync(minify: boolean): Promise<void> {
         : undefined,
     permissions: permissions !== null ? permissions : undefined,
     capabilities: capabilities !== null ? capabilities : undefined,
+    codegenLanguages: codegenLanguages !== null ? codegenLanguages : undefined,
+    codegenPreferences:
+      codegenPreferences !== null
+        ? createCodegenPreferences(codegenPreferences)
+        : undefined,
     enableProposedApi: enableProposedApi === true ? true : undefined,
     enablePrivatePluginApi: enablePrivatePluginApi === true ? true : undefined,
     build: build !== null ? build : undefined
@@ -170,6 +183,67 @@ function createRelaunchButtons(
     if (relaunchButton.multipleSelection === true) {
       result.multipleSelection = true
     }
+    return result
+  })
+}
+
+function createCodegenPreferenceOptions(
+  options: Array<ConfigCodegenPreferenceOption>
+): Array<ManifestCodegenPreferenceOption> {
+  return options.map(function (
+    option: ConfigCodegenPreferenceOption
+  ): ManifestCodegenPreferenceOption {
+    const result: ManifestCodegenPreferenceOption = {
+      label: option.label,
+      value: option.value
+    }
+
+    if (option.isDefault === true) {
+      result.isDefault = true
+    }
+
+    return result
+  })
+}
+
+function createCodegenPreferences(
+  preferences: Array<ConfigCodegenPreference>
+): Array<ManifestCodegenPreference> {
+  return preferences.map(function (
+    preference: ConfigCodegenPreference
+  ): ManifestCodegenPreference {
+    const result: ManifestCodegenPreference = {
+      itemType: preference.itemType
+    }
+
+    if (preference.defaultScaleFactor !== null) {
+      result.defaultScaleFactor = preference.defaultScaleFactor
+    }
+
+    if (preference.scaledUnit !== null) {
+      result.scaledUnit = preference.scaledUnit
+    }
+
+    if (preference.default === true) {
+      result.default = true
+    }
+
+    if (preference.propertyName !== null) {
+      result.propertyName = preference.propertyName
+    }
+
+    if (preference.label !== null) {
+      result.label = preference.label
+    }
+
+    if (preference.options !== null) {
+      result.options = createCodegenPreferenceOptions(preference.options)
+    }
+
+    if (preference.includedLanguages !== null) {
+      result.includedLanguages = preference.includedLanguages
+    }
+
     return result
   })
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,6 +4,9 @@ export { log } from './log.js'
 export { readConfigAsync } from './read-config-async.js'
 export {
   Config,
+  ConfigCodegenPreference,
+  ConfigCodegenPreferenceOption,
+  ConfigCodeLanguage,
   ConfigCommand,
   ConfigCommandSeparator,
   ConfigFile,
@@ -12,6 +15,9 @@ export {
 } from './types/config.js'
 export {
   RawConfig,
+  RawConfigCodegenPreference,
+  RawConfigCodegenPreferenceOption,
+  RawConfigCodeLanguage,
   RawConfigCommand,
   RawConfigCommandSeparator,
   RawConfigFile,

--- a/packages/common/src/read-config-async.ts
+++ b/packages/common/src/read-config-async.ts
@@ -5,6 +5,8 @@ import { join } from 'path'
 import { constants } from './constants.js'
 import {
   Config,
+  ConfigCodegenPreference,
+  ConfigCodegenPreferenceOption,
   ConfigCommand,
   ConfigCommandSeparator,
   ConfigFile,
@@ -13,6 +15,8 @@ import {
 } from './types/config.js'
 import {
   RawConfig,
+  RawConfigCodegenPreference,
+  RawConfigCodegenPreferenceOption,
   RawConfigCommand,
   RawConfigCommandSeparator,
   RawConfigFile,
@@ -24,6 +28,8 @@ const defaultConfig: Config = {
   api: constants.build.manifestPluginApi,
   build: null,
   capabilities: null,
+  codegenLanguages: null,
+  codegenPreferences: null,
   commandId: join(constants.build.srcDirectoryName, 'main.ts--default'),
   containsWidget: false,
   editorType: ['figma'],
@@ -60,6 +66,8 @@ export async function readConfigAsync(): Promise<Config> {
     api,
     build,
     capabilities,
+    codegenLanguages,
+    codegenPreferences,
     containsWidget,
     editorType,
     enableProposedApi,
@@ -79,6 +87,12 @@ export async function readConfigAsync(): Promise<Config> {
     api: typeof api === 'undefined' ? constants.build.manifestPluginApi : api,
     build: typeof build === 'undefined' ? null : build,
     capabilities: typeof capabilities === 'undefined' ? null : capabilities,
+    codegenLanguages:
+      typeof codegenLanguages === 'undefined' ? null : codegenLanguages,
+    codegenPreferences:
+      typeof codegenPreferences === 'undefined'
+        ? null
+        : parseCodegenPreferences(codegenPreferences),
     containsWidget:
       typeof containsWidget === 'undefined' ? false : containsWidget,
     editorType: typeof editorType === 'undefined' ? ['figma'] : editorType,
@@ -174,6 +188,61 @@ function parseCommandId(main: RawConfigFile): string {
     return `${src}--default`
   }
   return `${src}--${handler}`
+}
+
+function parseCodegenPreferenceOptions(
+  options: Array<RawConfigCodegenPreferenceOption>
+): Array<ConfigCodegenPreferenceOption> {
+  const result: Array<ConfigCodegenPreferenceOption> = []
+
+  for (const option of options) {
+    const { label, value, isDefault } = option
+
+    result.push({
+      isDefault: typeof isDefault === 'undefined' ? false : isDefault,
+      label,
+      value
+    })
+  }
+
+  return result
+}
+
+function parseCodegenPreferences(
+  preferences: Array<RawConfigCodegenPreference>
+): Array<ConfigCodegenPreference> {
+  const result: Array<ConfigCodegenPreference> = []
+
+  for (const preference of preferences) {
+    const {
+      itemType,
+      defaultScaleFactor,
+      scaledUnit,
+      default: defaultProperty,
+      propertyName,
+      label,
+      options,
+      includedLanguages
+    } = preference
+
+    result.push({
+      default: typeof defaultProperty === 'undefined' ? false : defaultProperty,
+      defaultScaleFactor:
+        typeof defaultScaleFactor === 'undefined' ? null : defaultScaleFactor,
+      includedLanguages:
+        typeof includedLanguages === 'undefined' ? null : includedLanguages,
+      itemType,
+      label: typeof label === 'undefined' ? null : label,
+      options:
+        typeof options === 'undefined'
+          ? null
+          : parseCodegenPreferenceOptions(options),
+      propertyName: typeof propertyName === 'undefined' ? null : propertyName,
+      scaledUnit: typeof scaledUnit === 'undefined' ? null : scaledUnit
+    })
+  }
+
+  return result
 }
 
 function parseFile(file: RawConfigFile): ConfigFile {

--- a/packages/common/src/types/config.ts
+++ b/packages/common/src/types/config.ts
@@ -20,6 +20,8 @@ export interface Config extends ConfigCommand {
   readonly relaunchButtons: null | Array<ConfigRelaunchButton>
   readonly permissions: null | Array<string>
   readonly capabilities: null | Array<string>
+  readonly codegenLanguages: null | Array<ConfigCodeLanguage>
+  readonly codegenPreferences: null | Array<ConfigCodegenPreference>
   readonly enableProposedApi: boolean
   readonly enablePrivatePluginApi: boolean
   readonly build: null | string
@@ -44,4 +46,26 @@ export interface ConfigRelaunchButton extends BaseConfigMixin {
   readonly commandId: string
   readonly main: ConfigFile
   readonly multipleSelection: boolean
+}
+
+export type ConfigCodeLanguage = {
+  readonly label: string
+  readonly value: string
+}
+
+export type ConfigCodegenPreferenceOption = {
+  readonly label: string
+  readonly value: string
+  readonly isDefault: null | boolean
+}
+
+export type ConfigCodegenPreference = {
+  readonly itemType: string
+  readonly defaultScaleFactor: null | number
+  readonly scaledUnit: null | string
+  readonly default: null | boolean
+  readonly propertyName: null | string
+  readonly label: null | string
+  readonly options: null | Array<ConfigCodegenPreferenceOption>
+  readonly includedLanguages: null | Array<string>
 }

--- a/packages/common/src/types/raw-config.ts
+++ b/packages/common/src/types/raw-config.ts
@@ -19,6 +19,8 @@ export interface RawConfig extends RawConfigCommand {
   readonly relaunchButtons?: RawConfigRelaunchButtons
   readonly permissions?: Array<string>
   readonly capabilities?: Array<string>
+  readonly codegenLanguages?: Array<RawConfigCodeLanguage>
+  readonly codegenPreferences?: Array<RawConfigCodegenPreference>
   readonly enableProposedApi?: boolean
   readonly enablePrivatePluginApi?: boolean
   readonly build?: string
@@ -47,4 +49,26 @@ export interface RawConfigRelaunchButton extends BaseRawConfigMixin {
 
 export type RawConfigRelaunchButtons = {
   readonly [relaunchButtonId: string]: RawConfigRelaunchButton
+}
+
+export type RawConfigCodeLanguage = {
+  readonly label: string
+  readonly value: string
+}
+
+export type RawConfigCodegenPreferenceOption = {
+  readonly label: string
+  readonly value: string
+  readonly isDefault?: boolean
+}
+
+export type RawConfigCodegenPreference = {
+  readonly itemType: string
+  readonly defaultScaleFactor?: number
+  readonly scaledUnit?: string
+  readonly default?: boolean
+  readonly propertyName?: string
+  readonly label?: string
+  readonly options?: Array<RawConfigCodegenPreferenceOption>
+  readonly includedLanguages?: Array<string>
 }

--- a/packages/common/test/additional-fields/additional-fields.ts
+++ b/packages/common/test/additional-fields/additional-fields.ts
@@ -7,6 +7,8 @@ import { readConfigAsync } from '../../src/read-config-async.js'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const config = {
+  codegenLanguages: null,
+  codegenPreferences: null,
   commandId: 'b--default',
   id: 'a',
   main: { handler: 'default', src: 'b' },
@@ -162,6 +164,63 @@ test('`build`', async function (t) {
     api: '1.0.0',
     build: 'c',
     capabilities: null,
+    containsWidget: false,
+    editorType: ['figma'],
+    enablePrivatePluginApi: false,
+    enableProposedApi: false,
+    permissions: null,
+    widgetApi: '1.0.0'
+  })
+})
+
+test('`codegen`', async function (t) {
+  t.plan(1)
+  process.chdir(join(__dirname, 'fixtures', '10-codegen'))
+  t.deepEqual(await readConfigAsync(), {
+    ...config,
+    api: '1.0.0',
+    build: null,
+    capabilities: ['codegen'],
+    codegenLanguages: [
+      { label: 'React', value: 'react' },
+      { label: 'Typescript', value: 'typescript' }
+    ],
+    codegenPreferences: [
+      {
+        default: true,
+        defaultScaleFactor: 16,
+        includedLanguages: ['react'],
+        itemType: 'unit',
+        label: null,
+        options: null,
+        propertyName: null,
+        scaledUnit: 'Rem'
+      },
+      {
+        default: false,
+        defaultScaleFactor: null,
+        includedLanguages: ['typescript'],
+        itemType: 'select',
+        label: 'Tab Size',
+        options: [
+          { isDefault: true, label: '2', value: '2' },
+          { isDefault: false, label: '4', value: '4' },
+          { isDefault: false, label: '8', value: '8' }
+        ],
+        propertyName: 'tabSize',
+        scaledUnit: null
+      },
+      {
+        default: false,
+        defaultScaleFactor: null,
+        includedLanguages: ['typescript'],
+        itemType: 'action',
+        label: 'More settings...',
+        options: null,
+        propertyName: 'showMore',
+        scaledUnit: null
+      }
+    ],
     containsWidget: false,
     editorType: ['figma'],
     enablePrivatePluginApi: false,

--- a/packages/common/test/additional-fields/fixtures/10-codegen/package.json
+++ b/packages/common/test/additional-fields/fixtures/10-codegen/package.json
@@ -1,0 +1,61 @@
+{
+  "figma-plugin": {
+    "name": "a",
+    "main": "b",
+    "capabilities": [
+      "codegen"
+    ],
+    "codegenLanguages": [
+      {
+        "label": "React",
+        "value": "react"
+      },
+      {
+        "label": "Typescript",
+        "value": "typescript"
+      }
+    ],
+    "codegenPreferences": [
+      {
+        "itemType": "unit",
+        "scaledUnit": "Rem",
+        "defaultScaleFactor": 16,
+        "default": true,
+        "includedLanguages": [
+          "react"
+        ]
+      },
+      {
+        "itemType": "select",
+        "propertyName": "tabSize",
+        "label": "Tab Size",
+        "options": [
+          {
+            "label": "2",
+            "value": "2",
+            "isDefault": true
+          },
+          {
+            "label": "4",
+            "value": "4"
+          },
+          {
+            "label": "8",
+            "value": "8"
+          }
+        ],
+        "includedLanguages": [
+          "typescript"
+        ]
+      },
+      {
+        "itemType": "action",
+        "propertyName": "showMore",
+        "label": "More settings...",
+        "includedLanguages": [
+          "typescript"
+        ]
+      }
+    ]
+  }
+}

--- a/packages/common/test/basic-command-with-parameters/basic-command-with-parameters.ts
+++ b/packages/common/test/basic-command-with-parameters/basic-command-with-parameters.ts
@@ -10,6 +10,8 @@ const config = {
   api: '1.0.0',
   build: null,
   capabilities: null,
+  codegenLanguages: null,
+  codegenPreferences: null,
   commandId: 'b--default',
   containsWidget: false,
   editorType: ['figma'],

--- a/packages/common/test/basic-command/basic-command.ts
+++ b/packages/common/test/basic-command/basic-command.ts
@@ -10,6 +10,8 @@ const config = {
   api: '1.0.0',
   build: null,
   capabilities: null,
+  codegenLanguages: null,
+  codegenPreferences: null,
   containsWidget: false,
   editorType: ['figma'],
   enablePrivatePluginApi: false,

--- a/packages/common/test/empty/empty.ts
+++ b/packages/common/test/empty/empty.ts
@@ -10,6 +10,8 @@ const config = {
   api: '1.0.0',
   build: null,
   capabilities: null,
+  codegenLanguages: null,
+  codegenPreferences: null,
   commandId: 'src/main.ts--default',
   containsWidget: false,
   editorType: ['figma'],

--- a/packages/common/test/multiple-menu-commands/multiple-menu-commands.ts
+++ b/packages/common/test/multiple-menu-commands/multiple-menu-commands.ts
@@ -10,6 +10,8 @@ const config = {
   api: '1.0.0',
   build: null,
   capabilities: null,
+  codegenLanguages: null,
+  codegenPreferences: null,
   commandId: null,
   containsWidget: false,
   editorType: ['figma'],

--- a/packages/common/test/relaunch-buttons/relaunch-buttons.ts
+++ b/packages/common/test/relaunch-buttons/relaunch-buttons.ts
@@ -10,6 +10,8 @@ const config = {
   api: '1.0.0',
   build: null,
   capabilities: null,
+  codegenLanguages: null,
+  codegenPreferences: null,
   commandId: 'b--default',
   containsWidget: false,
   editorType: ['figma'],

--- a/packages/common/test/single-menu-command-with-parameters/single-menu-command-with-parameters.ts
+++ b/packages/common/test/single-menu-command-with-parameters/single-menu-command-with-parameters.ts
@@ -10,6 +10,8 @@ const config = {
   api: '1.0.0',
   build: null,
   capabilities: null,
+  codegenLanguages: null,
+  codegenPreferences: null,
   commandId: null,
   containsWidget: false,
   editorType: ['figma'],

--- a/packages/common/test/single-menu-command/single-menu-command.ts
+++ b/packages/common/test/single-menu-command/single-menu-command.ts
@@ -10,6 +10,8 @@ const config = {
   api: '1.0.0',
   build: null,
   capabilities: null,
+  codegenLanguages: null,
+  codegenPreferences: null,
   commandId: null,
   containsWidget: false,
   editorType: ['figma'],


### PR DESCRIPTION
Adds support for Figma's new codegen capabilities in dev mode.

https://www.figma.com/plugin-docs/codegen-plugins/
https://www.figma.com/plugin-docs/api/codegenPreference
https://www.figma.com/plugin-docs/updates/2023/06/21/version-1-update-68