### PR TITLE
fix: expose css files in ui package exports

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,10 @@
   "files": [
     "lib"
   ],
-  "exports": "./lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./css/*.css": "./lib/css/*.css"
+  },
   "main": "./lib/index.js",
   "scripts": {
     "prebuild": "npm run clean",


### PR DESCRIPTION
## What's changed

Exposes the CSS defined in the `ui` package to consumers via the package exports map.

## Why

The UI package contains some global styles that are necessary for the UI components to be styled correctly. Typically:
- `ui/src/base.css` will land in the plugin bundle because it's imported via `ui/src/utilities/render.tsx`
- `ui/src/theme.css` won't land in the plugin bundle because it's not imported (and this file just replicates the CSS variables that Figma will insert in to the plugin UI frame anyway)

If a plugin author wishes to add Storybook to their plugin development environment, they will need to directly reference both `base.css` and `theme.css` ([much like the `@create-figma-plugin/ui` package itself does](https://github.com/yuanqing/create-figma-plugin/blob/a816a99324cc8b7ce38d527330b0017e4940e1e1/packages/ui/.storybook/preview.jsx#L1-L2)) in order to have stories render with the correct styles. However consumers aren't currently able to reference these files because there are no matching paths in the package.json `exports` map, so story bundling will fail because webpack will not be able to resolve `@create-figma-plugin/ui/lib/css/*.css` module references.

The new exports pattern introduced here will allow consumers to import the CSS files in to Storybook previews like so:

```ts
import '@create-figma-plugin/ui/css/theme.css';
import '@create-figma-plugin/ui/css/base.css';
```
