### PR TITLE
Add Dark Mode Support to Tailwind CSS Config 

### DIFF
--- a/packages/build/src/utilities/build-bundles-async/esbuild-css-modules-plugin.ts
+++ b/packages/build/src/utilities/build-bundles-async/esbuild-css-modules-plugin.ts
@@ -78,6 +78,7 @@ async function createCssFilePathAsync(
 }
 
 const backQuoteRegex = /`/g
+const colonRegex = /:/g
 
 async function createGlobalCssJavaScriptAsync(
   cssFilePath: string,
@@ -106,7 +107,7 @@ async function createGlobalCssJavaScriptAsync(
       element.id = '${elementId}';
       element.textContent = \`${css
         .replace(backQuoteRegex, '\\`')
-        .replace(/:/g, '\\:')}\`;
+        .replace(colonRegex, '\\:')}\`;
       document.head.${isBaseCss === true ? 'prepend' : 'append'}(element);
     }
     export default {};
@@ -151,7 +152,9 @@ async function createCssModulesJavaScriptAsync(
     if (document.getElementById('${elementId}') === null) {
       const element = document.createElement('style');
       element.id = '${elementId}';
-      element.textContent = \`${css.replace(backQuoteRegex, '\\`')}\`;
+      element.textContent = \`${css
+        .replace(backQuoteRegex, '\\`')
+        .replace(colonRegex, '\\:')}\`;
       document.head.append(element);
     }
     export default ${classNamesJson};

--- a/packages/build/src/utilities/build-bundles-async/esbuild-css-modules-plugin.ts
+++ b/packages/build/src/utilities/build-bundles-async/esbuild-css-modules-plugin.ts
@@ -104,7 +104,9 @@ async function createGlobalCssJavaScriptAsync(
     if (document.getElementById('${elementId}') === null) {
       const element = document.createElement('style');
       element.id = '${elementId}';
-      element.textContent = \`${css.replace(backQuoteRegex, '\\`')}\`;
+      element.textContent = \`${css
+        .replace(backQuoteRegex, '\\`')
+        .replace(/:/g, '\\:')}\`;
       document.head.${isBaseCss === true ? 'prepend' : 'append'}(element);
     }
     export default {};

--- a/packages/create-figma-plugin/templates/plugin/preact-tailwindcss/tailwind.config.js
+++ b/packages/create-figma-plugin/templates/plugin/preact-tailwindcss/tailwind.config.js
@@ -1,7 +1,9 @@
+/** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
     extend: {},
   },
-  plugins: []
+  plugins: [],
+  darkMode: ['class', '.figma-dark']
 }

--- a/packages/website/docs/ui.md
+++ b/packages/website/docs/ui.md
@@ -164,12 +164,14 @@ Then, create a [`tailwind.config.js`](https://tailwindcss.com/docs/configuration
 ```js
 // tailwind.config.js
 
+/** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
     extend: {},
   },
-  plugins: []
+  plugins: [],
+  darkMode: ['class', '.figma-dark']
 }
 ```
 


### PR DESCRIPTION
This pull request fixes #174 

Adds support for dark mode to the Tailwind CSS configuration. The configuration file has been updated to include a dark mode variant that is triggered using the `.figma-dark` class. 


**Changes Made:**

- Added the darkMode property to the Tailwind CSS configuration.
- Configured the dark mode variant to be triggered by the `.figma-dark` class.
- `Colons (:)` in class names are treated correctly in the esbuild file, escaping them using `double backslashes (\\:)`. This will ensure that the colons are interpreted as part of the class names and work as expected in the code.

Please review and let us know if any further adjustments are needed.