### PR TITLE
Add name to package.json templates

### DIFF
--- a/packages/create-figma-plugin/templates/plugin/hello-world/package.json
+++ b/packages/create-figma-plugin/templates/plugin/hello-world/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "<%- id %>",
   "dependencies": {
     "@create-figma-plugin/utilities": "^<%- versions.createFigmaPlugin.utilities %>"
   },

--- a/packages/create-figma-plugin/templates/plugin/preact-rectangles/package.json
+++ b/packages/create-figma-plugin/templates/plugin/preact-rectangles/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "<%- id %>",
   "dependencies": {
     "@create-figma-plugin/ui": "^<%- versions.createFigmaPlugin.ui %>",
     "@create-figma-plugin/utilities": "^<%- versions.createFigmaPlugin.utilities %>",

--- a/packages/create-figma-plugin/templates/plugin/preact-resizable/package.json
+++ b/packages/create-figma-plugin/templates/plugin/preact-resizable/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "<%- id %>",
   "dependencies": {
     "@create-figma-plugin/ui": "^<%- versions.createFigmaPlugin.ui %>",
     "@create-figma-plugin/utilities": "^<%- versions.createFigmaPlugin.utilities %>",

--- a/packages/create-figma-plugin/templates/plugin/preact-tailwindcss/package.json
+++ b/packages/create-figma-plugin/templates/plugin/preact-tailwindcss/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "<%- id %>",
   "dependencies": {
     "@create-figma-plugin/ui": "^<%- versions.createFigmaPlugin.ui %>",
     "@create-figma-plugin/utilities": "^<%- versions.createFigmaPlugin.utilities %>",

--- a/packages/create-figma-plugin/templates/plugin/react-editor/package.json
+++ b/packages/create-figma-plugin/templates/plugin/react-editor/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "<%- id %>",
   "dependencies": {
     "@create-figma-plugin/ui": "^<%- versions.createFigmaPlugin.ui %>",
     "@create-figma-plugin/utilities": "^<%- versions.createFigmaPlugin.utilities %>",

--- a/packages/create-figma-plugin/templates/widget/notepad/package.json
+++ b/packages/create-figma-plugin/templates/widget/notepad/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "<%- id %>",
   "dependencies": {
     "@create-figma-plugin/ui": "^<%- versions.createFigmaPlugin.ui %>",
     "@create-figma-plugin/utilities": "^<%- versions.createFigmaPlugin.utilities %>",


### PR DESCRIPTION
Add a name field using the id template variable to the root of the template package.json files so that they appear correctly as packages in a workspace