### PR TITLE
Add option to exclude files

### DIFF
--- a/packages/create-figma-plugin/src/cli.ts
+++ b/packages/create-figma-plugin/src/cli.ts
@@ -6,11 +6,16 @@ import { createFigmaPluginAsync } from './create-figma-plugin-async.js'
 sade('create-figma-plugin [name]', true)
   .describe('Initialize a new Figma/FigJam plugin using a template')
   .option('-t, --template', 'The name of the template to use')
+  .option(
+    '-e, --exclude',
+    'Excludes copying these files from templates. Comma separated list file1.ts,file2.ts'
+  )
   .action(async function (
     name: string,
-    options: { template: string }
+    options: { template: string; exclude: string }
   ): Promise<void> {
     await createFigmaPluginAsync({
+      exclude: options.exclude,
       name,
       template: options.template
     })

--- a/packages/create-figma-plugin/src/create-figma-plugin-async.ts
+++ b/packages/create-figma-plugin/src/create-figma-plugin-async.ts
@@ -15,6 +15,7 @@ import { resolveTemplateNameAsync } from './utilities/resolve-template-name-asyn
 export async function createFigmaPluginAsync(options: {
   name?: string
   template?: string
+  exclude?: string
 }): Promise<void> {
   try {
     const templateName = await resolveTemplateNameAsync(options.template)
@@ -26,7 +27,8 @@ export async function createFigmaPluginAsync(options: {
         : basename(templateName)
     const directoryPath = await resolveDirectoryPathAsync(directoryName)
     log.info(`Copying "${templateName}" template...`)
-    await copyTemplateAsync(templateName, directoryPath)
+
+    await copyTemplateAsync(templateName, directoryPath, options.exclude)
     log.info('Resolving package versions...')
     const versions = await resolveCreateFigmaPluginLatestStableVersions()
     await interpolateValuesIntoFilesAsync(directoryPath, {

--- a/packages/create-figma-plugin/src/utilities/copy-template-async.ts
+++ b/packages/create-figma-plugin/src/utilities/copy-template-async.ts
@@ -8,7 +8,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export async function copyTemplateAsync(
   templateName: string,
-  pluginDirectoryPath: string
+  pluginDirectoryPath: string,
+  exclude?: string
 ): Promise<void> {
   const templateDirectory = resolve(
     __dirname,
@@ -20,7 +21,14 @@ export async function copyTemplateAsync(
   if ((await pathExists(pluginDirectoryPath)) === false) {
     await fs.mkdir(pluginDirectoryPath, { mode: 0o2775 })
   }
-  await fs.cp(templateDirectory, pluginDirectoryPath, { recursive: true })
+  const excludes = exclude?.split(',') || []
+  await fs.cp(templateDirectory, pluginDirectoryPath, {
+    filter: (source) => {
+      // Skip the source file if it is in the excludes list
+      return !excludes?.some((file) => source.includes(file))
+    },
+    recursive: true
+  })
   const gitIgnoreFilePath = join(pluginDirectoryPath, 'gitignore')
   if ((await pathExists(gitIgnoreFilePath)) === true) {
     const newFilePath = join(pluginDirectoryPath, '.gitignore')


### PR DESCRIPTION
Comma separated list to exclude files from a template.
Useful for when using workspaces and a top level tsconfig, so need to exclude the default tsconfig from a new template to allow workspace: aliases to work correctly