### PR TITLE
Escaping CSS class names for improved rendering

### DIFF
--- a/packages/build/src/utilities/build-bundles-async/esbuild-css-modules-plugin.ts
+++ b/packages/build/src/utilities/build-bundles-async/esbuild-css-modules-plugin.ts
@@ -77,8 +77,7 @@ async function createCssFilePathAsync(
   return result
 }
 
-const backQuoteRegex = /`/g
-const backSlashColonRegex = /\\:/g
+const nonAlphanumericRegex = /[^a-zA-Z0-9-_]/g
 
 async function createGlobalCssJavaScriptAsync(
   cssFilePath: string,
@@ -105,9 +104,9 @@ async function createGlobalCssJavaScriptAsync(
     if (document.getElementById('${elementId}') === null) {
       const element = document.createElement('style');
       element.id = '${elementId}';
-      element.innerHTML = \`${css
-        .replace(backQuoteRegex, '\\`')
-        .replace(backSlashColonRegex, '\\\\:')}\`;
+      element.innerHTML = \`${css.replace(nonAlphanumericRegex, (match) => {
+        return `\\${match}`
+      })}\`;
       document.head.${isBaseCss === true ? 'prepend' : 'append'}(element);
     }
     export default {};
@@ -152,9 +151,9 @@ async function createCssModulesJavaScriptAsync(
     if (document.getElementById('${elementId}') === null) {
       const element = document.createElement('style');
       element.id = '${elementId}';
-      element.textContent = \`${css
-        .replace(backQuoteRegex, '\\`')
-        .replace(backSlashColonRegex, '\\\\:')}\`;
+      element.textContent = \`${css.replace(nonAlphanumericRegex, (match) => {
+        return `\\${match}`
+      })}\`;
       document.head.append(element);
     }
     export default ${classNamesJson};


### PR DESCRIPTION
 **Fix: Rendering of CSS Class Names with Special Characters**

In standard CSS naming conventions, class names can include alphanumeric characters, hyphens, and underscores. However, special characters require escaping to ensure proper rendering. This pull request introduces a regex-based solution that replaces special characters with their corresponding escape sequences. This fix guarantees correct rendering of class names containing special characters.

With this fix, the following code snippets can now be displayed correctly:

```html
<div class="!bg-red-500">...</div>
<div class="py-0.5">...</div>
<div class="w-[100px]">...</div>
<div class="hover:text-gray-200">...</div>
```
