### PR TITLE
Fix codegen plugins with menu

### DIFF
--- a/packages/build/src/utilities/build-bundles-async/build-bundles-async.ts
+++ b/packages/build/src/utilities/build-bundles-async/build-bundles-async.ts
@@ -110,7 +110,7 @@ function createMainEntryFile(config: Config): string {
     const modules = ${createRequireCode(entryFiles)};
     const commandId = (${
       entryFiles.length === 1
-    } || typeof figma.command === 'undefined' || figma.command === '') ? '${
+    } || typeof figma.command === 'undefined' || figma.command === '' || figma.command === 'generate') ? '${
     entryFiles[0].commandId
   }' : figma.command;
     modules[commandId]();


### PR DESCRIPTION
Interpret `figma.command` as empty/undefined if It is equal to 'generate'
See https://github.com/yuanqing/create-figma-plugin/issues/202 for more details