### PR TITLE
docs: Update the Figma quick action command

### DIFF
--- a/packages/create-figma-plugin/templates/plugin/hello-world/README.md
+++ b/packages/create-figma-plugin/templates/plugin/hello-world/README.md
@@ -35,7 +35,7 @@ $ npm run watch
 
 Use `console.log` statements to inspect values in your code.
 
-To open the developer console, search for and run `Open Console` via the Quick Actions search bar.
+To open the developer console, search for and run `Show/Hide Console` via the Quick Actions search bar.
 
 ## See also
 

--- a/packages/create-figma-plugin/templates/plugin/preact-rectangles/README.md
+++ b/packages/create-figma-plugin/templates/plugin/preact-rectangles/README.md
@@ -35,7 +35,7 @@ $ npm run watch
 
 Use `console.log` statements to inspect values in your code.
 
-To open the developer console, search for and run `Open Console` via the Quick Actions search bar.
+To open the developer console, search for and run `Show/Hide Console` via the Quick Actions search bar.
 
 ## See also
 

--- a/packages/create-figma-plugin/templates/plugin/preact-resizable/README.md
+++ b/packages/create-figma-plugin/templates/plugin/preact-resizable/README.md
@@ -35,7 +35,7 @@ $ npm run watch
 
 Use `console.log` statements to inspect values in your code.
 
-To open the developer console, search for and run `Open Console` via the Quick Actions search bar.
+To open the developer console, search for and run `Show/Hide Console` via the Quick Actions search bar.
 
 ## See also
 

--- a/packages/create-figma-plugin/templates/plugin/preact-tailwindcss/README.md
+++ b/packages/create-figma-plugin/templates/plugin/preact-tailwindcss/README.md
@@ -35,7 +35,7 @@ $ npm run watch
 
 Use `console.log` statements to inspect values in your code.
 
-To open the developer console, search for and run `Open Console` via the Quick Actions search bar.
+To open the developer console, search for and run `Show/Hide Console` via the Quick Actions search bar.
 
 ## See also
 

--- a/packages/create-figma-plugin/templates/plugin/react-editor/README.md
+++ b/packages/create-figma-plugin/templates/plugin/react-editor/README.md
@@ -35,7 +35,7 @@ $ npm run watch
 
 Use `console.log` statements to inspect values in your code.
 
-To open the developer console, search for and run `Open Console` via the Quick Actions search bar.
+To open the developer console, search for and run `Show/Hide Console` via the Quick Actions search bar.
 
 ## See also
 

--- a/packages/create-figma-plugin/templates/widget/notepad/README.md
+++ b/packages/create-figma-plugin/templates/widget/notepad/README.md
@@ -35,7 +35,7 @@ $ npm run watch
 
 Use `console.log` statements to inspect values in your code.
 
-To open the developer console, search for and run `Open Console` via the Quick Actions search bar.
+To open the developer console, search for and run `Show/Hide Console` via the Quick Actions search bar.
 
 ## See also
 

--- a/packages/website/docs/quick-start.md
+++ b/packages/website/docs/quick-start.md
@@ -128,7 +128,7 @@ Learn how to:
 
 Use `console.log` statements to inspect values in your code.
 
-To open the developer console, search for and run `Open Console` via the Quick Actions search bar.
+To open the developer console, search for and run `Show/Hide Console` via the Quick Actions search bar.
 
 ## Publishing to Figma Community
 


### PR DESCRIPTION
Update the docs based on how Figma actually calls the "Open console" action, see the following screenshot 😊

<img width="439" alt="image" src="https://github.com/yuanqing/create-figma-plugin/assets/173663/4a207c04-0b15-4f7a-83b6-016b88482663">
