### PR TITLE
Fix Windows

### DIFF
--- a/packages/build/src/utilities/build-bundles-async/build-bundles-async.ts
+++ b/packages/build/src/utilities/build-bundles-async/build-bundles-async.ts
@@ -18,7 +18,7 @@ import { importFresh } from '../import-fresh.js'
 import { esbuildCssModulesPlugin } from './esbuild-css-modules-plugin.js'
 import { esbuildPreactCompatPlugin } from './esbuild-preact-compat-plugin.js'
 
-const isWindows = platform() === 'win32';
+const isWindows = platform() === 'win32'
 
 interface EntryFile extends ConfigFile {
   commandId: string
@@ -57,7 +57,7 @@ async function overrideEsbuildConfigAsync(
     return buildOptions
   }
   if (isWindows) {
-    filePaths = filePaths.map(p => pathToFileURL(p).href);
+    filePaths = filePaths.map(p => pathToFileURL(p).href)
   }
   const overrideEsbuildConfig:
     | OverrideEsbuildConfig

--- a/packages/build/src/utilities/build-bundles-async/build-bundles-async.ts
+++ b/packages/build/src/utilities/build-bundles-async/build-bundles-async.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path'
+import { platform } from 'node:os'
 
 import {
   Config,
@@ -48,9 +49,12 @@ async function overrideEsbuildConfigAsync(
   buildOptions: BuildOptions,
   configGlobPattern: string
 ): Promise<BuildOptions> {
-  const filePaths = await globby(configGlobPattern, { absolute: true })
+  let filePaths = await globby(configGlobPattern, { absolute: true })
   if (filePaths.length === 0) {
     return buildOptions
+  }
+  if (platform() === 'win32') {
+    filePaths = `file://${filePaths}`;
   }
   const overrideEsbuildConfig:
     | OverrideEsbuildConfig

--- a/packages/build/src/utilities/build-bundles-async/build-bundles-async.ts
+++ b/packages/build/src/utilities/build-bundles-async/build-bundles-async.ts
@@ -54,7 +54,7 @@ async function overrideEsbuildConfigAsync(
     return buildOptions
   }
   if (platform() === 'win32') {
-    filePaths = `file://${filePaths}`;
+    filePaths = filePaths.map(p => `file:///${p}`);
   }
   const overrideEsbuildConfig:
     | OverrideEsbuildConfig

--- a/packages/build/src/utilities/build-bundles-async/build-bundles-async.ts
+++ b/packages/build/src/utilities/build-bundles-async/build-bundles-async.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 import { platform } from 'node:os'
+import { pathToFileURL } from 'node:url'
 
 import {
   Config,
@@ -16,6 +17,8 @@ import indentString from 'indent-string'
 import { importFresh } from '../import-fresh.js'
 import { esbuildCssModulesPlugin } from './esbuild-css-modules-plugin.js'
 import { esbuildPreactCompatPlugin } from './esbuild-preact-compat-plugin.js'
+
+const isWindows = platform() === 'win32';
 
 interface EntryFile extends ConfigFile {
   commandId: string
@@ -53,8 +56,8 @@ async function overrideEsbuildConfigAsync(
   if (filePaths.length === 0) {
     return buildOptions
   }
-  if (platform() === 'win32') {
-    filePaths = filePaths.map(p => `file:///${p}`);
+  if (isWindows) {
+    filePaths = filePaths.map(p => pathToFileURL(p).href);
   }
   const overrideEsbuildConfig:
     | OverrideEsbuildConfig


### PR DESCRIPTION
Fixes #205.

This change appends the `file://` protocol to windows paths to the error below
(technically we let `pathToFileURL` from `node:url` do the work)
```
ESBuild: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader.
On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```


