### PR TITLE
fix: once() autoremoves when done

### DIFF
--- a/packages/utilities/src/events.ts
+++ b/packages/utilities/src/events.ts
@@ -37,13 +37,15 @@ export function once<Handler extends EventHandler>(
   handler: Handler['handler']
 ): () => void {
   let done = false
-  return on(name, function (...args): void {
+  const dispose = on(name, function (...args): void {
     if (done === true) {
       return
     }
     done = true
+    dispose()
     handler(...args)
-  })
+  });
+  return dispose
 }
 
 /**


### PR DESCRIPTION
Since once done it's safe to remove, do it for the user so he does not forget and ends up with memory leaks :)