### PR TITLE
fix: pointer cursor is active on text inside a button

### DIFF
--- a/packages/ui/src/components/button/button.module.css
+++ b/packages/ui/src/components/button/button.module.css
@@ -121,6 +121,7 @@
 
 .children {
   display: inline;
+  cursor: inherit;
 }
 .loading .children {
   visibility: hidden;


### PR DESCRIPTION
bugfix: when hovering on the text inside a button we want to continue showing a pointer. The cursor setting is set to `default` vs `pointer` so we need to override it its children. or use a span instead.

<img width="1635" alt="image" src="https://github.com/user-attachments/assets/49379e6d-0159-48e9-bef6-1632581fc71d">