### PR TITLE
fix: pin tailwindcss version to ^3.4.17 in preact-tailwindcss template

### DIFF
--- a/packages/create-figma-plugin/templates/plugin/preact-tailwindcss/package.json
+++ b/packages/create-figma-plugin/templates/plugin/preact-tailwindcss/package.json
@@ -9,7 +9,7 @@
     "@create-figma-plugin/tsconfig": "^<%- versions.createFigmaPlugin.tsconfig %>",
     "@figma/plugin-typings": "<%- versions.figma.pluginTypings %>",
     "concurrently": ">=8",
-    "tailwindcss": ">=3",
+    "tailwindcss": "^3.4.17",
     "typescript": ">=5"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Pin TailwindCSS version from `>=3` to `^3.4.17` in the preact-tailwindcss template
- Ensures consistent behavior and prevents potential breaking changes from newer major versions 