### PR TITLE
fix(ui): correct progress track display for range slider with non-zero minimum values

### DIFF
--- a/packages/ui/src/components/range-slider/range-slider.tsx
+++ b/packages/ui/src/components/range-slider/range-slider.tsx
@@ -89,12 +89,13 @@ export const RangeSlider = createComponent<HTMLInputElement, RangeSliderProps>(
     const renderProgressTrack = useCallback(function (options: {
       value: number
       maximum: number
+      minimum: number
     }) {
-      const { value, maximum } = options
+      const { value, maximum, minimum } = options
       const inputElement = getCurrentFromRef(inputElementRef)
       const inputElementWidth = inputElement.offsetWidth
       const sliderThumbElementWidth = inputElement.offsetHeight
-      const percentage = value / maximum
+      const percentage = (value - minimum) / (maximum - minimum)
       const px = `${
         percentage * (inputElementWidth - sliderThumbElementWidth) +
         sliderThumbElementWidth / 2
@@ -104,9 +105,9 @@ export const RangeSlider = createComponent<HTMLInputElement, RangeSliderProps>(
 
     useEffect(
       function () {
-        renderProgressTrack({ maximum, value: parseFloat(value) })
+        renderProgressTrack({ maximum, minimum, value: parseFloat(value) })
       },
-      [maximum, renderProgressTrack, value]
+      [maximum, minimum, renderProgressTrack, value]
     )
 
     return (


### PR DESCRIPTION
## Problem
The range slider progress track displays incorrectly when the minimum value is non-zero. For example, with a range of minimum=2 and maximum=5, when the slider is at the minimum position (value=2), the progress track shows 40% fill instead of 0%.
![image](https://github.com/user-attachments/assets/e012293c-3705-4a72-867f-a5e1ceda0a8c)
![image](https://github.com/user-attachments/assets/74fcf148-8b39-42cf-96ef-27cb8968e453)
![image](https://github.com/user-attachments/assets/8b900d76-02ac-49fc-8a20-ab7f449fd9d2)

## Solution
Updated the `renderProgressTrack` function to properly calculate the percentage relative to the actual range by:
- Including `minimum` parameter in the function options
- Changing percentage calculation from `value / maximum` to `(value - minimum) / (maximum - minimum)`
- Adding `minimum` to the `useEffect` dependency array

## Changes
- Modified `renderProgressTrack` function signature to accept `minimum` parameter
- Fixed percentage calculation to account for non-zero minimum values
- Updated `useEffect` call to pass `minimum` value and include it in dependencies

## Testing
- With minimum=2, maximum=5, value=2: progress track now shows 0% (was 40%)
- With minimum=2, maximum=5, value=5: progress track shows 100% (was 100%)
- With minimum=2, maximum=5, value=3: progress track shows 33.3% (was 42.8%)

Fixes the progress track visual representation to correctly reflect the slider's position within its actual range.