### PR TITLE
fix(create-figma-plugin): Tailwind CSS directive

### DIFF
--- a/packages/create-figma-plugin/templates/plugin/preact-tailwindcss/src/input.css
+++ b/packages/create-figma-plugin/templates/plugin/preact-tailwindcss/src/input.css
@@ -1,3 +1,1 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";


### PR DESCRIPTION
In the `package.json` we have `"tailwindcss": ">=4"` specified, but the old `@tailwind` directives are still used in the `input.css` file.

It has not worked since v4. [Upgrade guide](https://tailwindcss.com/docs/upgrade-guide#removed-tailwind-directives).

This PR fixes it.