### PR TITLE
Fix: RangeSlider progress fill does not update its width on window resize of plugin

### DIFF
--- a/packages/ui/src/components/range-slider/range-slider.tsx
+++ b/packages/ui/src/components/range-slider/range-slider.tsx
@@ -93,6 +93,9 @@ export const RangeSlider = createComponent<HTMLInputElement, RangeSliderProps>(
     }) {
       const { value, maximum, minimum } = options
       const inputElement = getCurrentFromRef(inputElementRef)
+      if (inputElement === null) {
+          return;
+      }
       const inputElementWidth = inputElement.offsetWidth
       const sliderThumbElementWidth = inputElement.offsetHeight
       const percentage = (value - minimum) / (maximum - minimum)
@@ -109,7 +112,15 @@ export const RangeSlider = createComponent<HTMLInputElement, RangeSliderProps>(
       },
       [maximum, minimum, renderProgressTrack, value]
     )
-
+    useEffect(function () {
+        const handleResize = function () {
+            renderProgressTrack({ maximum, minimum, value: parseFloat(value) });
+        };
+        window.addEventListener('resize', handleResize);
+        return function () {
+            window.removeEventListener('resize', handleResize);
+        };
+    }, [maximum, minimum, renderProgressTrack, value]);
     return (
       <label
         class={createClassName([

--- a/packages/ui/src/components/range-slider/range-slider.tsx
+++ b/packages/ui/src/components/range-slider/range-slider.tsx
@@ -94,7 +94,7 @@ export const RangeSlider = createComponent<HTMLInputElement, RangeSliderProps>(
       const { value, maximum, minimum } = options
       const inputElement = getCurrentFromRef(inputElementRef)
       if (inputElement === null) {
-          return;
+          return
       }
       const inputElementWidth = inputElement.offsetWidth
       const sliderThumbElementWidth = inputElement.offsetHeight
@@ -109,18 +109,17 @@ export const RangeSlider = createComponent<HTMLInputElement, RangeSliderProps>(
     useEffect(
       function () {
         renderProgressTrack({ maximum, minimum, value: parseFloat(value) })
+        const handleResize = function () {
+            renderProgressTrack({ maximum, minimum, value: parseFloat(value) })
+        }
+        window.addEventListener('resize', handleResize)
+        return function () {
+            window.removeEventListener('resize', handleResize)
+        }
       },
       [maximum, minimum, renderProgressTrack, value]
     )
-    useEffect(function () {
-        const handleResize = function () {
-            renderProgressTrack({ maximum, minimum, value: parseFloat(value) });
-        };
-        window.addEventListener('resize', handleResize);
-        return function () {
-            window.removeEventListener('resize', handleResize);
-        };
-    }, [maximum, minimum, renderProgressTrack, value]);
+
     return (
       <label
         class={createClassName([


### PR DESCRIPTION
This is a proposed fix to the following issue: [RangeSlider progress fill does not update its width on window resize of plugin](https://github.com/yuanqing/create-figma-plugin/issues/268)

The fix entails the following:
1. added a null check for inputElement in renderProgressTrack to prevent errors if the element isn't mounted yet
2. within the same useEffect that initially renders the progress track, included a resize listener to recalculate the progress track width on window resize
